### PR TITLE
Add v1.project_secrets

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -35,6 +35,7 @@ tables/v1/project_fact_history.sql
 tables/v1/project_facts.sql
 tables/v1/project_link_types.sql
 tables/v1/project_links.sql
+tables/v1/project_secrets.sql
 tables/v1/project_score_history.sql
 tables/v1/project_urls.sql
 tables/v1/users.sql

--- a/tables/v1/project_secrets.sql
+++ b/tables/v1/project_secrets.sql
@@ -1,0 +1,25 @@
+SET search_path=v1;
+
+CREATE TABLE IF NOT EXISTS project_secrets (
+  project_id        INTEGER                     NOT NULL,
+  name              TEXT                        NOT NULL,
+  value             TEXT                        NOT NULL,
+  created_at        TIMESTAMP WITH TIME ZONE    NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+  created_by        TEXT                        NOT NULL,
+  last_modified_at  TIMESTAMP WITH TIME ZONE,
+  last_modified_by  TEXT,
+  PRIMARY KEY (project_id, name),
+  FOREIGN KEY (project_id) REFERENCES projects (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+COMMENT ON TABLE project_secrets IS 'Stores encrypted secrets for a project';
+COMMENT ON COLUMN project_secrets.project_id IS 'The project ID';
+COMMENT ON COLUMN project_secrets.name IS 'The secret name';
+COMMENT ON COLUMN project_secrets.value IS 'The encrypted secret value';
+COMMENT ON COLUMN project_secrets.created_at IS 'When the record was created at';
+COMMENT ON COLUMN project_secrets.created_by IS 'The user created the record';
+COMMENT ON COLUMN project_secrets.last_modified_at IS 'When the record was last modified';
+COMMENT ON COLUMN project_secrets.last_modified_by IS 'The user that last modified the record';
+
+GRANT SELECT ON project_secrets TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON project_secrets TO writer;

--- a/tests/test_v1_project_secrets.sql
+++ b/tests/test_v1_project_secrets.sql
@@ -1,0 +1,53 @@
+BEGIN;
+
+SELECT plan(12);
+
+SELECT lives_ok(
+  $$INSERT INTO v1.namespaces (id, name, created_by, slug, icon_class) VALUES (1, 'test_namespace', 'test_user', 'test_slug', 'test_icon_class')$$,
+  'create namespace');
+
+SELECT lives_ok(
+  $$INSERT INTO v1.project_types (id, name, plural_name, created_by, slug) VALUES (1, 'test_project_type', 'tests', 'test_user', 'test_slug')$$,
+  'create project type');
+
+SELECT lives_ok(
+  $$INSERT INTO v1.projects (id, namespace_id, project_type_id, created_by, name, slug) VALUES (1, 1, 1, 'test_user', 'test_project_1', 'test_slug_1')$$,
+  'create first project');
+
+SELECT lives_ok(
+  $$INSERT INTO v1.projects (id, namespace_id, project_type_id, created_by, name, slug) VALUES (2, 1, 1, 'test_user', 'test_project_2', 'test_slug_2')$$,
+  'create second project');
+
+SELECT throws_ok(
+  $$INSERT INTO v1.project_secrets (project_id, "name", value, created_by) VALUES (0, 'name', 'value', 'me')$$,
+  23503, NULL, 'INSERT fails when providing nonexistent project ID');
+
+SELECT throws_ok(
+  $$INSERT INTO v1.project_secrets (project_id, "name", value, created_by) VALUES (NULL, 'name', 'value', 'me')$$,
+  23502, NULL, 'INSERT fails when providing NULL project ID');
+
+SELECT throws_ok(
+  $$INSERT INTO v1.project_secrets (project_id, "name", value, created_by) VALUES (1, NULL, 'value', 'me')$$,
+  23502, NULL, 'INSERT fails when providing NULL secret name');
+
+SELECT throws_ok(
+  $$INSERT INTO v1.project_secrets (project_id, "name", value, created_by) VALUES (1, 'name', NULL, 'me')$$,
+  23502, NULL, 'INSERT fails when providing NULL secret value');
+
+SELECT lives_ok(
+  $$INSERT INTO v1.project_secrets (project_id, "name", value, created_by) VALUES (1, 'secret name', 'value', 'me')$$,
+  'insert a secret for project 1');
+
+SELECT throws_ok(
+  $$INSERT INTO v1.project_secrets (project_id, "name", value, created_by) VALUES (1, 'secret name', 'value', 'me')$$,
+  23505, NULL, 'INSERT duplicate secret name for project 1 fails');
+
+SELECT lives_ok(
+  $$INSERT INTO v1.project_secrets (project_id, "name", value, created_by) VALUES (2, 'secret name', 'value', 'me')$$,
+  'INSERT same secret name for project 2 succeeds');
+
+SELECT lives_ok(
+  $$INSERT INTO v1.project_secrets (project_id, "name", value, created_by) VALUES (1, 'different secret name', 'value', 'me')$$,
+  'INSERT different secret name for project 1 succeeds');
+
+ROLLBACK;

--- a/tests/test_v1_tables.sql
+++ b/tests/test_v1_tables.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(23);
+SELECT plan(24);
 
 SELECT has_table('v1'::NAME, 'authentication_tokens'::NAME);
 SELECT has_table('v1'::NAME, 'cookie_cutters'::NAME);
@@ -18,8 +18,9 @@ SELECT has_table('v1'::NAME, 'project_fact_types'::NAME);
 SELECT has_table('v1'::NAME, 'project_facts'::NAME);
 SELECT has_table('v1'::NAME, 'project_link_types'::NAME);
 SELECT has_table('v1'::NAME, 'project_links'::NAME);
-SELECT has_table('v1'::NAME, 'project_types'::NAME);
 SELECT has_table('v1'::NAME, 'project_score_history'::NAME);
+SELECT has_table('v1'::NAME, 'project_secrets'::NAME);
+SELECT has_table('v1'::NAME, 'project_types'::NAME);
 SELECT has_table('v1'::NAME, 'project_urls'::NAME);
 SELECT has_table('v1'::NAME, 'projects'::NAME);
 SELECT has_table('v1'::NAME, 'user_oauth2_tokens'::NAME);


### PR DESCRIPTION
This table will be used to store encrypted secrets for projects. Initially it will be used to store the DSN assigned to a project when it is registered in sentry.  As new project-specific secrets are added, this is where they will live.

I left the "name" of the secret as a free form text string.  I plan on using something like "sentry_dsn" for the name of the Sentry DSN secret.  It would be great to constrain this further (e.g, using an enum or lookup table) but I think that would unnecessarily restrict the usage.

I did consider allowing the `project_id` to be `NULL` to represent configuration secrets such as API tokens that imbi uses (e.g., Sentry & SonarQube API tokens).  I'm not sure if that is something that we want to consider or not since it would be nice to get those tokens out of the configuration file and into secure storage.  We can change this later if we want since it widening the restriction  **Thoughts?**

Associated with https://github.com/AWeber-Imbi/imbi/issues/60