### PR TITLE
Fixes the boolean fact history population

### DIFF
--- a/functions/v1/insert_project_fact_history.sql
+++ b/functions/v1/insert_project_fact_history.sql
@@ -23,6 +23,10 @@ CREATE FUNCTION insert_project_fact_history() RETURNS trigger
         FROM v1.project_fact_type_ranges
        WHERE fact_type_id = NEW.fact_type_id
          AND NEW.value::NUMERIC(9,2) BETWEEN min_value AND max_value;
+    ELSIF (fact_type.data_type = 'boolean') THEN
+      IF NEW.value = 'true' THEN
+        fact_score := 100;
+      END IF;
     END IF;
 
     INSERT INTO v1.project_fact_history(project_id, fact_type_id, recorded_at, recorded_by, value, score, weight)

--- a/tests/test_v1_project_facts.sql
+++ b/tests/test_v1_project_facts.sql
@@ -1,5 +1,5 @@
 BEGIN;
-  SELECT PLAN(25);
+  SELECT PLAN(28);
 
   SELECT lives_ok(
     $$INSERT INTO v1.namespaces (id, name, created_by, slug, icon_class) VALUES (1, 'test_namespace', 'test_user', 'test_slug', 'test_icon_class')$$,
@@ -132,6 +132,25 @@ BEGIN;
     ORDER BY recorded_at DESC
        LIMIT 1$$,
     $$VALUES ('92.6', 25, 100)$$,
+    'the expected record is in the fact history table');
+
+  SELECT lives_ok(
+    $$INSERT INTO v1.project_fact_types (id, project_type_ids, name, data_type, created_by, weight) VALUES (4, '{1}', 'bool_fact', 'boolean', 'test_user', 25)$$,
+    'create boolean fact_type');
+
+  SELECT lives_ok(
+    $$INSERT INTO v1.project_facts (project_id, fact_type_id, recorded_at, recorded_by, value) VALUES (1, 4, CURRENT_TIMESTAMP - interval '1 day', 'test_user', 'true')$$,
+    'create a boolean fact');
+
+  SELECT results_eq(
+    $$SELECT value, weight, score
+        FROM v1.project_fact_history
+       WHERE project_id = 1
+         AND fact_type_id = 4
+         AND score = 100
+    ORDER BY recorded_at DESC
+       LIMIT 1$$,
+    $$VALUES ('true', 25, 100)$$,
     'the expected record is in the fact history table');
 
   SELECT results_eq(


### PR DESCRIPTION
This ensures that boolean values are stored in the fact_history_table with a score of 100 in the fact history table.