### PR TITLE
Add surrogate notes key

### DIFF
--- a/tables/v1/project_notes.sql
+++ b/tables/v1/project_notes.sql
@@ -4,19 +4,19 @@ DROP TABLE IF EXISTS project_notes;
 
 CREATE TABLE project_notes (
     project_id INTEGER,
-    recorded_by TEXT,
-    recorded_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    created_by TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     content TEXT NOT NULL,
     updated_by TEXT,
     updated_at TIMESTAMP WITH TIME ZONE,
-    PRIMARY KEY (project_id, recorded_at, recorded_by),
+    PRIMARY KEY (project_id, created_at, created_by),
     FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 COMMENT ON TABLE project_notes IS 'Stores notes about a project';
 COMMENT ON COLUMN project_notes.project_id IS 'The project ID';
-COMMENT ON COLUMN project_notes.recorded_by IS 'The user that created the note';
-COMMENT ON COLUMN project_notes.recorded_at IS 'Time that the note was created';
+COMMENT ON COLUMN project_notes.created_by IS 'The user that created the note';
+COMMENT ON COLUMN project_notes.created_at IS 'Time that the note was created';
 COMMENT ON COLUMN project_notes.content IS 'Textual content of the note';
 COMMENT ON COLUMN project_notes.updated_by IS 'The user that last updated the note';
 COMMENT ON COLUMN project_notes.updated_at IS 'Time that the note was last updated or NULL';

--- a/tables/v1/project_notes.sql
+++ b/tables/v1/project_notes.sql
@@ -3,17 +3,19 @@ SET SEARCH_PATH TO v1;
 DROP TABLE IF EXISTS project_notes;
 
 CREATE TABLE project_notes (
-    project_id INTEGER,
-    created_by TEXT,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    content TEXT NOT NULL,
-    updated_by TEXT,
-    updated_at TIMESTAMP WITH TIME ZONE,
-    PRIMARY KEY (project_id, created_at, created_by),
+    id            SERIAL                   NOT NULL  PRIMARY KEY,
+    project_id    INTEGER                  NOT NULL,
+    created_by    TEXT                     NOT NULL,
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    content       TEXT                     NOT NULL,
+    updated_by    TEXT,
+    updated_at    TIMESTAMP WITH TIME ZONE,
+    UNIQUE (project_id, created_at, created_by),
     FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 COMMENT ON TABLE project_notes IS 'Stores notes about a project';
+COMMENT ON COLUMN project_notes.id IS 'Surrogate key for URLs and linking';
 COMMENT ON COLUMN project_notes.project_id IS 'The project ID';
 COMMENT ON COLUMN project_notes.created_by IS 'The user that created the note';
 COMMENT ON COLUMN project_notes.created_at IS 'Time that the note was created';

--- a/tests/test_v1_project_notes.sql
+++ b/tests/test_v1_project_notes.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(20);
+SELECT plan(21);
 
 -- create some fixtures
 
@@ -39,6 +39,9 @@ SELECT throws_ok(
 SELECT throws_ok(
     $$INSERT INTO v1.project_notes (project_id, content, created_by) VALUES (1, 'some text content', NULL)$$,
     '23502', NULL, 'INSERT fails with NULL created_by');
+SELECT throws_ok(
+    $$INSERT INTO v1.project_notes (id, project_id, content, created_by) VALUES (NULL, 1, 'some text content', 'test_user')$$,
+    '42703', NULL, 'INSERT fails with NULL id');
 
 SET ROLE TO reader;
 SELECT lives_ok($$SELECT * FROM v1.project_notes$$, 'reader can read notes');

--- a/tests/test_v1_project_notes.sql
+++ b/tests/test_v1_project_notes.sql
@@ -16,34 +16,34 @@ SELECT lives_ok(
 
 -- now we can start testing
 
-SELECT col_is_pk('v1', 'project_notes', ARRAY['project_id', 'recorded_at', 'recorded_by'], 'PK is (project_id, recorded_at, recorded_by)');
+SELECT col_is_pk('v1', 'project_notes', ARRAY['project_id', 'created_at', 'created_by'], 'PK is (project_id, created_at, created_by)');
 
 SELECT lives_ok(
-    $$INSERT INTO v1.project_notes (project_id, content, recorded_by) VALUES (1, 'some text content', 'test_user')$$,
+    $$INSERT INTO v1.project_notes (project_id, content, created_by) VALUES (1, 'some text content', 'test_user')$$,
     'create a valid note');
-SELECT ok(updated_at IS NULL, 'updated_at is NULL for new note') FROM v1.project_notes WHERE project_id = 1 AND recorded_by = 'test_user';
-SELECT ok(updated_by IS NULL, 'updated_by is NULL for new note') FROM v1.project_notes WHERE project_id = 1 AND recorded_by = 'test_user';
+SELECT ok(updated_at IS NULL, 'updated_at is NULL for new note') FROM v1.project_notes WHERE project_id = 1 AND created_by = 'test_user';
+SELECT ok(updated_by IS NULL, 'updated_by is NULL for new note') FROM v1.project_notes WHERE project_id = 1 AND created_by = 'test_user';
 
 SELECT throws_ok(
-    $$INSERT INTO v1.project_notes (project_id, content, recorded_by) VALUES (2, 'some text content', 'test_user')$$,
+    $$INSERT INTO v1.project_notes (project_id, content, created_by) VALUES (2, 'some text content', 'test_user')$$,
     '23503', NULL, 'INSERT fails for nonexistent project ID');
 SELECT throws_ok(
-    $$INSERT INTO v1.project_notes (project_id, content, recorded_by) VALUES (NULL, 'some text content', 'text_user')$$,
+    $$INSERT INTO v1.project_notes (project_id, content, created_by) VALUES (NULL, 'some text content', 'text_user')$$,
     '23502', NULL, 'INSERT fails with NULL project_id');
 SELECT throws_ok(
-    $$INSERT INTO v1.project_notes (project_id, content, recorded_by) VALUES (1, NULL, 'text_user')$$,
+    $$INSERT INTO v1.project_notes (project_id, content, created_by) VALUES (1, NULL, 'text_user')$$,
     '23502', NULL, 'INSERT fails with NULL content');
 SELECT throws_ok(
-    $$INSERT INTO v1.project_notes (project_id, content, recorded_by, recorded_at) VALUES (1, 'some text content', 'test_user', NULL)$$,
-    '23502', NULL, 'INSERT fails with NULL recorded_at');
+    $$INSERT INTO v1.project_notes (project_id, content, created_by, created_at) VALUES (1, 'some text content', 'test_user', NULL)$$,
+    '23502', NULL, 'INSERT fails with NULL created_at');
 SELECT throws_ok(
-    $$INSERT INTO v1.project_notes (project_id, content, recorded_by) VALUES (1, 'some text content', NULL)$$,
-    '23502', NULL, 'INSERT fails with NULL recorded_by');
+    $$INSERT INTO v1.project_notes (project_id, content, created_by) VALUES (1, 'some text content', NULL)$$,
+    '23502', NULL, 'INSERT fails with NULL created_by');
 
 SET ROLE TO reader;
 SELECT lives_ok($$SELECT * FROM v1.project_notes$$, 'reader can read notes');
 SELECT throws_ok(
-    $$INSERT INTO v1.project_notes (project_id, content, recorded_by) VALUES (1, 'some text', 'me')$$,
+    $$INSERT INTO v1.project_notes (project_id, content, created_by) VALUES (1, 'some text', 'me')$$,
     '42501', NULL, 'reader cannot create a note');
 SELECT throws_ok(
     $$UPDATE v1.project_notes SET content = 'other content'$$, '42501', NULL, 'reader cannot update notes');
@@ -52,10 +52,10 @@ SELECT throws_ok($$DELETE FROM v1.project_notes$$, '42501', NULL, 'reader cannot
 SET ROLE TO writer;
 SELECT lives_ok($$SELECT * FROM v1.project_notes$$, 'writer can read notes');
 SELECT lives_ok(
-    $$INSERT INTO v1.project_notes (project_id, content, recorded_by) VALUES (1, 'inserted', 'me')$$,
+    $$INSERT INTO v1.project_notes (project_id, content, created_by) VALUES (1, 'inserted', 'me')$$,
     'writer can insert notes');
 SELECT lives_ok(
-    $$UPDATE v1.project_notes SET content = 'to be deleted' WHERE recorded_by = 'me' AND content = 'inserted'$$,
+    $$UPDATE v1.project_notes SET content = 'to be deleted' WHERE created_by = 'me' AND content = 'inserted'$$,
     'writer can update notes');
 SELECT lives_ok($$DELETE FROM v1.project_notes WHERE content = 'to be deleted'$$, 'writer can delete notes');
 


### PR DESCRIPTION
Not having a surrogate key for notes made changes to the API much more complicated than they needed to be since much of the machinery expects one.  I also changed the column names to match expectations in the API implementation.