### PR TITLE
Fix project score calculation

### DIFF
--- a/functions/v1/project_score.sql
+++ b/functions/v1/project_score.sql
@@ -49,10 +49,11 @@ CREATE OR REPLACE FUNCTION project_score(IN in_project_id INTEGER) RETURNS NUMER
                         WHERE project_type_id = ANY(a.project_type_ids)
                           AND a.weight > 0
     LOOP
-      fact_weight := fact_record.weight / total_weight;
+      fact_weight := fact_record.weight;
       weighted_score := fact_record.score * fact_weight;
       score := score + weighted_score;
     END LOOP;
+    score := score / total_weight;
   RETURN score;
 END
 $$;


### PR DESCRIPTION
This fixes a small accumulation of errors that can occur in the last loop of the function. Since it divides by weighted_score multiple times, very small rounding errors can accumulate and will prevent some project types, for example, from being able to get a score of 100 (instead, it will show 99). We can move the division to the end, and do it only once, as this is mathematically equivalent and doesn't accumulate errors.