### PR TITLE
Bump precision in score calculation variable

### DIFF
--- a/functions/v1/project_score.sql
+++ b/functions/v1/project_score.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION project_score(IN in_project_id INTEGER) RETURNS NUMER
     fact_weight      NUMERIC(9,5);
     score            NUMERIC(9,2) := 0;
     total_weight     NUMERIC(9,5);
-    weighted_score   NUMERIC(9,5);
+    weighted_score   NUMERIC(10,5);
   BEGIN
     SELECT projects.project_type_id INTO STRICT project_type_id
       FROM v1.projects


### PR DESCRIPTION
This fixes an edge case where you have a single fact type for a project with weight 100, and a fact value with score 100 (such as boolean True). This maximum value will exceed the NUMERIC(9,5) size of the weighted_score variable. So we just bump the precision here from 9 to 10. This doesn't cause downstream precision problems because weighted_score is only used on the following line which truncates to (9,2) on each iteration.