### PR TITLE
Fix typo in maintaining LDAP groups

### DIFF
--- a/functions/v1/maintain_group_membership_from_ldap_groups.sql
+++ b/functions/v1/maintain_group_membership_from_ldap_groups.sql
@@ -32,7 +32,7 @@ BEGIN
 
   -- Delete any LDAP group memberships not passed in
   DELETE FROM v1.group_members
-        WHERE username = username
+        WHERE username = in_username
           AND "group" IN (SELECT "name"
                             FROM v1.groups
                            WHERE group_type = 'ldap'


### PR DESCRIPTION
This was deleting every group membership for other members (not the user themselves) who didn't share their groups.