### PR TITLE
Add external project identifiers

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -22,6 +22,7 @@ types/v1/fact_type.sql
 tables/v1/environments.sql
 tables/v1/namespaces.sql
 tables/v1/namespace_kpi_history.sql
+tables/v1/integrations.sql
 tables/v1/oauth2_integrations.sql
 tables/v1/project_types.sql
 tables/v1/cookie_cutters.sql

--- a/MANIFEST
+++ b/MANIFEST
@@ -34,6 +34,7 @@ tables/v1/project_fact_type_enums.sql
 tables/v1/project_fact_type_ranges.sql
 tables/v1/project_fact_history.sql
 tables/v1/project_facts.sql
+tables/v1/project_identifiers.sql
 tables/v1/project_link_types.sql
 tables/v1/project_links.sql
 tables/v1/project_notes.sql

--- a/tables/v1/integrations.sql
+++ b/tables/v1/integrations.sql
@@ -1,0 +1,24 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE IF NOT EXISTS integrations (
+    "name"            TEXT                      NOT NULL  PRIMARY KEY,
+    created_at        TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    created_by        TEXT                      NOT NULL  DEFAULT 'system',
+    last_modified_at  TIMESTAMP WITH TIME ZONE,
+    last_modified_by  TEXT,
+    api_endpoint      TEXT                      NOT NULL,
+    api_secret        TEXT
+);
+
+COMMENT ON TABLE integrations IS 'Integrated Applications';
+
+COMMENT ON COLUMN integrations.name IS 'The common name of the application';
+COMMENT ON COLUMN integrations.created_at IS 'When the record was created at';
+COMMENT ON COLUMN integrations.created_by IS 'The user that created the application';
+COMMENT ON COLUMN integrations.last_modified_at IS 'When the record was was last modified at';
+COMMENT ON COLUMN integrations.last_modified_by IS 'The user that last modified the record';
+COMMENT ON COLUMN integrations.api_endpoint IS 'URL for the root of the application API';
+COMMENT ON COLUMN integrations.api_secret IS 'Optional global secret for this application';
+
+GRANT SELECT ON integrations TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON integrations to admin;

--- a/tables/v1/project_identifiers.sql
+++ b/tables/v1/project_identifiers.sql
@@ -1,0 +1,27 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE IF NOT EXISTS project_identifiers (
+    external_id       TEXT NOT NULL,
+    integration_name  TEXT NOT NULL,
+    project_id        INT NOT NULL,
+    created_at        TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    created_by        TEXT                      NOT NULL  DEFAULT 'system',
+    last_modified_at  TIMESTAMP WITH TIME ZONE,
+    last_modified_by  TEXT,
+    PRIMARY KEY (integration_name, project_id),
+    FOREIGN KEY (integration_name) REFERENCES v1.integrations (name) ON UPDATE CASCADE ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES v1.projects (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+COMMENT ON TABLE project_identifiers IS 'Surrogate identifiers for Imbi projects';
+
+COMMENT ON COLUMN project_identifiers.external_id IS 'Identifier for the project in `integration_name`';
+COMMENT ON COLUMN project_identifiers.integration_name IS 'Name of the application that owns this identifier';
+COMMENT ON COLUMN project_identifiers.project_id IS 'Imbi project that the identifier refers to';
+COMMENT ON COLUMN project_identifiers.created_at IS 'When the record was created at';
+COMMENT ON COLUMN project_identifiers.created_by IS 'The user that created the application';
+COMMENT ON COLUMN project_identifiers.last_modified_at IS 'When the record was was last modified at';
+COMMENT ON COLUMN project_identifiers.last_modified_by IS 'The user that last modified the record';
+
+GRANT SELECT ON project_identifiers TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON project_identifiers to writer;

--- a/tables/v1/project_identifiers.sql
+++ b/tables/v1/project_identifiers.sql
@@ -25,3 +25,4 @@ COMMENT ON COLUMN project_identifiers.last_modified_by IS 'The user that last mo
 
 GRANT SELECT ON project_identifiers TO reader;
 GRANT SELECT, INSERT, UPDATE, DELETE ON project_identifiers to writer;
+GRANT SELECT, INSERT, UPDATE, DELETE ON project_identifiers to admin;

--- a/tests/test_v1_integrations.sql
+++ b/tests/test_v1_integrations.sql
@@ -1,0 +1,51 @@
+BEGIN;
+
+SELECT plan(15);
+
+SELECT col_is_pk('v1', 'integrations', ARRAY['name'], 'PK is (name)');
+
+SELECT lives_ok(
+    $$INSERT INTO v1.integrations (name, api_endpoint)
+      VALUES ('integration-1', 'https://example.com/integration-1')$$,
+    'create a valid integration');
+SELECT ok(created_at IS NOT NULL, 'created_at is NOT NULL for new integration')
+  FROM v1.integrations
+ WHERE name = 'gitlab';
+SELECT ok(created_by IS NOT NULL, 'created_by is NOT NULL for new integration')
+  FROM v1.integrations
+ WHERE name = 'gitlab';
+SELECT ok(last_modified_at IS NULL, 'last_modified_at is NULL for new integration')
+  FROM v1.integrations
+ WHERE name = 'gitlab';
+SELECT ok(last_modified_by IS NULL, 'last_modified_by is NULL for new integration')
+  FROM v1.integrations
+ WHERE name = 'gitlab';
+
+SELECT throws_ok(
+    $$INSERT INTO v1.integrations (name) VALUES ('whatever')$$,
+    '23502', NULL, 'INSERT fails without api_endpoint');
+
+-- reader can read
+SET ROLE TO reader;
+SELECT lives_ok($$SELECT * FROM v1.integrations$$, 'reader can read');
+SELECT throws_ok($$INSERT INTO v1.integrations (name, api_endpoint) VALUES ('whatever', 'https://example.com')$$, '42501', NULL, 'reader cannot insert');
+SELECT throws_ok($$UPDATE v1.integrations SET name = 'github'$$, '42501', NULL, 'reader cannot update');
+SELECT throws_ok($$DELETE FROM v1.integrations WHERE name = 'github'$$, '42501', NULL, 'reader cannot delete');
+
+-- writer can only read
+SET ROLE TO writer;
+SELECT lives_ok($$SELECT * FROM v1.integrations$$, 'writer can read');
+SELECT throws_ok($$INSERT INTO v1.integrations (name, api_endpoint) VALUES ('whatever', 'https://example.com')$$, '42501', NULL, 'write cannot insert');
+SELECT throws_ok($$UPDATE v1.integrations SET name = 'github'$$, '42501', NULL, 'writer cannot update');
+SELECT throws_ok($$DELETE FROM v1.integrations WHERE name = 'github'$$, '42501', NULL, 'writer cannot delete');
+
+-- admin can write
+SET ROLE TO admin;
+SELECT lives_ok($$SELECT * FROM v1.integrations$$, 'admin can read');
+SELECT lives_ok($$INSERT INTO v1.integrations (name, api_endpoint) VALUES ('whatever', 'https://example.com')$$, 'admin can insert');
+SELECT lives_ok($$UPDATE v1.integrations SET name = 'integration-2' WHERE name = 'whatever'$$, 'admin can update');
+SELECT lives_ok($$DELETE FROM v1.integrations WHERE name = 'github'$$, 'admin can delete');
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/test_v1_project_identifiers.sql
+++ b/tests/test_v1_project_identifiers.sql
@@ -1,0 +1,120 @@
+BEGIN;
+
+SELECT plan(32);
+
+-- fixtures
+
+SELECT lives_ok(
+  $$INSERT INTO v1.namespaces (id, name, created_by, slug, icon_class) VALUES (1, 'test_namespace', 'test_user', 'test_slug', 'test_icon_class')$$,
+  'create namespace');
+SELECT lives_ok(
+  $$INSERT INTO v1.project_types (id, name, plural_name, created_by, slug) VALUES (1, 'test_project_type', 'tests', 'test_user', 'test_slug')$$,
+  'create project type');
+SELECT lives_ok(
+  $$INSERT INTO v1.projects (id, namespace_id, project_type_id, created_by, name, slug) VALUES (1, 1, 1, 'test_user', 'test_project_1', 'test_slug_1')$$,
+  'create first project');
+SELECT lives_ok(
+  $$INSERT INTO v1.projects (id, namespace_id, project_type_id, created_by, name, slug) VALUES (2, 1, 1, 'test_user', 'test_project_2', 'test_slug_2')$$,
+  'create second project');
+SELECT lives_ok(
+  $$INSERT INTO v1.projects (id, namespace_id, project_type_id, created_by, name, slug) VALUES (3, 1, 1, 'test_user', 'test_project_3', 'test_slug_3')$$,
+  'create third project');
+SELECT lives_ok(
+  $$INSERT INTO v1.integrations (name, api_endpoint) VALUES ('integration-1', 'https://example.com/integration-1')$$,
+  'create first integration');
+SELECT lives_ok(
+  $$INSERT INTO v1.integrations (name, api_endpoint) VALUES ('integration-2', 'https://example.com/integration-2')$$,
+  'create second integration');
+SELECT lives_ok(
+  $$INSERT INTO v1.integrations (name, api_endpoint) VALUES ('integration-3', 'https://example.com/integration-3')$$,
+  'create third integration');
+
+SELECT lives_ok(
+  $$
+  INSERT INTO v1.project_identifiers (external_id, integration_name, project_id)
+                              VALUES ('project-2', 'integration-2', 2),
+                                     ('project-3', 'integration-3', 3)
+  $$,
+  'create project identifiers');
+
+-- tests
+
+SELECT lives_ok(
+    $$INSERT INTO v1.project_identifiers(external_id, integration_name, project_id)
+      VALUES ('project-1', 'integration-1', 1)$$,
+    'create valid project identifier');
+SELECT ok(created_at IS NOT NULL, 'created_at is NOT NULL for new identifier')
+  FROM v1.project_identifiers
+ WHERE integration_name = 'integration-1'
+   AND project_id = 1;
+SELECT ok(created_by IS NOT NULL, 'created_by is NOT NULL for new identifier')
+  FROM v1.project_identifiers
+ WHERE integration_name = 'integrations-1'
+   AND project_id = 1;
+SELECT ok(last_modified_at IS NULL, 'last_modified_at is NULL for new identifier')
+  FROM v1.project_identifiers
+ WHERE integration_name = 'integrations-1'
+    AND project_id = 1;
+SELECT ok(last_modified_by IS NULL, 'last_modified_by is NULL for new identifier')
+  FROM v1.project_identifiers
+ WHERE integration_name = 'integrations-1'
+    AND project_id = 1;
+
+SELECT throws_ok(
+    $$INSERT INTO v1.project_identifiers (external_id, integration_name, project_id)
+      VALUES ('project-1', 'integration-1', 1)$$,
+               '23505', NULL, 'INSERT fails on duplicate');
+SELECT throws_ok(
+    $$INSERT INTO v1.project_identifiers (integration_name, project_id)
+      VALUES ('integration-1', 1)$$,
+    '23502', NULL, 'INSERT fails without external_id');
+SELECT throws_ok(
+    $$INSERT INTO v1.project_identifiers (external_id, integration_name, project_id)
+      VALUES (NULL, 'integration-1', 1)$$,
+    '23502', NULL, 'INSERT fails with NULL external_id');
+SELECT throws_ok(
+    $$INSERT INTO v1.project_identifiers (external_id, integration_name, project_id)
+      VALUES ('whatever', 'integration-1', 100)$$,
+    '23503', NULL, 'INSERT fails with unknown project_id');
+SELECT throws_ok(
+    $$INSERT INTO v1.project_identifiers (external_id, integration_name, project_id)
+      VALUES ('whatever', 'imbi', 1)$$,
+    '23503', NULL, 'INSERT fails with invalid integration_name');
+
+SELECT lives_ok($$DELETE FROM v1.projects WHERE id = 2$$, 'delete second project');
+SELECT ok(COUNT(project_id) = 0, 'project deletion cascades')
+  FROM v1.project_identifiers
+ WHERE project_id = 2;
+
+SELECT lives_ok($$DELETE FROM v1.integrations WHERE name = 'integration-3'$$, 'delete second integration');
+SELECT ok(COUNT(project_id) = 0, 'integration deletion cascades')
+  FROM v1.project_identifiers
+ WHERE project_id = 3;
+
+-- reader can read
+SET ROLE TO reader;
+SELECT lives_ok($$SELECT * FROM v1.project_identifiers$$, 'reader can read');
+SELECT throws_ok($$INSERT INTO v1.project_identifiers(external_id, integration_name, project_id)
+                   VALUES ('whatever', 'whatever', 1)$$, '42501', NULL, 'reader cannot insert');
+SELECT throws_ok($$UPDATE v1.project_identifiers SET integration_name = 'github'$$, '42501', NULL, 'reader cannot update');
+SELECT throws_ok($$DELETE FROM v1.project_identifiers WHERE integration_name = 'github'$$, '42501', NULL, 'reader cannot delete');
+
+-- writer can write
+SET ROLE TO writer;
+SELECT lives_ok($$SELECT * FROM v1.project_identifiers$$, 'writer can read');
+SELECT lives_ok($$INSERT INTO v1.project_identifiers(external_id, integration_name, project_id)
+                  VALUES ('whatever', 'integration-2', 1)$$, 'writer can insert');
+SELECT lives_ok($$UPDATE v1.project_identifiers SET external_id = 'whatever'$$, 'writer can update');
+SELECT lives_ok($$DELETE FROM v1.project_identifiers WHERE integration_name = 'github'$$, 'writer can delete');
+
+-- admin can write
+SET ROLE TO admin;
+SELECT lives_ok($$SELECT * FROM v1.project_identifiers$$, 'admin can read');
+SELECT lives_ok($$INSERT INTO v1.project_identifiers(external_id, integration_name, project_id)
+                  VALUES ('whatever', 'integration-2', 3)$$, 'admin can insert');
+SELECT lives_ok($$UPDATE v1.project_identifiers SET external_id = 'whatever'$$, 'admin can update');
+SELECT lives_ok($$DELETE FROM v1.project_identifiers WHERE integration_name = 'github'$$, 'admin can delete');
+
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
This PR adds a table to track identifiers for projects in other systems (eg, github, sentry, etc). The goal is to make it very easy to find projects using native identifiers for a system. This is particularly important for webhook processing since we generally only have the native identifier and need to update a specific imbi project.

The schema includes two new tables -- integrations, and project_identifiers. The former contains names for external systems that imbi knows about and the latter includes the unique identifier for the project in a different system. Both will be exposed in the FE and API in the future.