### PR TITLE
Add notification processing schema

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -17,12 +17,14 @@ types/v1/cookie_cutter_type.sql
 types/v1/data_type.sql
 types/v1/entity_type.sql
 types/v1/fact_type.sql
+types/v1/notification_action_type.sql
 
 -- Tables
 tables/v1/environments.sql
 tables/v1/namespaces.sql
 tables/v1/namespace_kpi_history.sql
 tables/v1/integrations.sql
+tables/v1/integration_notifications.sql
 tables/v1/oauth2_integrations.sql
 tables/v1/project_types.sql
 tables/v1/cookie_cutters.sql

--- a/MANIFEST
+++ b/MANIFEST
@@ -18,6 +18,7 @@ types/v1/data_type.sql
 types/v1/entity_type.sql
 types/v1/fact_type.sql
 types/v1/notification_action_type.sql
+types/v1/notification_filter_operation_type.sql
 
 -- Tables
 tables/v1/environments.sql
@@ -25,6 +26,7 @@ tables/v1/namespaces.sql
 tables/v1/namespace_kpi_history.sql
 tables/v1/integrations.sql
 tables/v1/integration_notifications.sql
+tables/v1/notification_filters.sql
 tables/v1/oauth2_integrations.sql
 tables/v1/project_types.sql
 tables/v1/cookie_cutters.sql

--- a/MANIFEST
+++ b/MANIFEST
@@ -36,6 +36,7 @@ tables/v1/project_dependencies.sql
 tables/v1/project_fact_types.sql
 tables/v1/project_fact_type_enums.sql
 tables/v1/project_fact_type_ranges.sql
+tables/v1/notification_rules.sql
 tables/v1/project_fact_history.sql
 tables/v1/project_facts.sql
 tables/v1/project_identifiers.sql

--- a/tables/v1/integration_notifications.sql
+++ b/tables/v1/integration_notifications.sql
@@ -1,0 +1,32 @@
+SET SEARCH_PATH to v1;
+
+CREATE TABLE IF NOT EXISTS integration_notifications (
+  notification_name  TEXT                      NOT NULL,
+  integration_name   TEXT                      NOT NULL,
+  id_pattern         TEXT                      NOT NULL,
+  documentation      TEXT,
+  verification_token TEXT,
+  default_action     notification_action_type  NOT NULL  DEFAULT 'process',
+  created_at         TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+  created_by         TEXT                      NOT NULL  DEFAULT 'system',
+  last_modified_at   TIMESTAMP WITH TIME ZONE,
+  last_modified_by   TEXT,
+  PRIMARY KEY (notification_name, integration_name),
+  FOREIGN KEY (integration_name) REFERENCES integrations (name) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+COMMENT ON TABLE integration_notifications IS 'Notifications from Integrated Applications';
+
+COMMENT ON COLUMN integration_notifications.notification_name IS 'Human-readable name of the notification';
+COMMENT ON COLUMN integration_notifications.integration_name IS 'Name of the integrated application that sends this notification';
+COMMENT ON COLUMN integration_notifications.id_pattern IS 'JSON pointer to the surrogate identifier in the notification';
+COMMENT ON COLUMN integration_notifications.documentation IS 'Optional link to API documentation';
+COMMENT ON COLUMN integration_notifications.verification_token IS 'Encrypted verification token for this specific notification';
+COMMENT ON COLUMN integration_notifications.default_action IS 'Should this notification be ignored or processed by default';
+COMMENT ON COLUMN integration_notifications.created_at IS 'When the record was created at';
+COMMENT ON COLUMN integration_notifications.created_by IS 'The user that created the record';
+COMMENT ON COLUMN integration_notifications.last_modified_at IS 'When the record was was last modified at';
+COMMENT ON COLUMN integration_notifications.last_modified_by IS 'The user that last modified the record';
+
+GRANT SELECT ON integration_notifications TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON integration_notifications TO admin;

--- a/tables/v1/notification_filters.sql
+++ b/tables/v1/notification_filters.sql
@@ -1,0 +1,38 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE IF NOT EXISTS notification_filters (
+  filter_name        TEXT                               NOT NULL,
+  integration_name   TEXT                               NOT NULL,
+  notification_name  TEXT                               NOT NULL,
+  pattern            TEXT                               NOT NULL,
+  operation          notification_filter_operation_type NOT NULL,
+  value              TEXT                               NOT NULL,
+  action             notification_action_type           NOT NULL,
+  created_at         TIMESTAMP WITH TIME ZONE           NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+  created_by         TEXT                               NOT NULL  DEFAULT 'system',
+  last_modified_at   TIMESTAMP WITH TIME ZONE,
+  last_modified_by   TEXT,
+     PRIMARY KEY (filter_name, integration_name, notification_name),
+     FOREIGN KEY (integration_name) REFERENCES integrations (name) ON DELETE CASCADE ON UPDATE CASCADE,
+     FOREIGN KEY (integration_name, notification_name)
+  REFERENCES integration_notifications (integration_name, notification_name)
+          ON DELETE CASCADE
+          ON UPDATE CASCADE
+);
+
+COMMENT ON TABLE notification_filters IS 'Accept/reject filters for incoming notifications';
+
+COMMENT ON COLUMN notification_filters.filter_name IS 'Human-readable name of the filter';
+COMMENT ON COLUMN notification_filters.integration_name IS 'Name of the integrated application that sends the notification';
+COMMENT ON COLUMN notification_filters.notification_name IS 'Human-readable name of the notification that this filter applies to';
+COMMENT ON COLUMN notification_filters.pattern IS 'JSON pointer to the property in the notification that this filter evaluates';
+COMMENT ON COLUMN notification_filters.operation IS 'Evaluation operation';
+COMMENT ON COLUMN notification_filters.value IS 'Evaluation value';
+COMMENT ON COLUMN notification_filters.action IS 'Action to apply if the filter evaluation matches';
+COMMENT ON COLUMN notification_filters.created_at IS 'When the record was created at';
+COMMENT ON COLUMN notification_filters.created_by IS 'The user that created the record';
+COMMENT ON COLUMN notification_filters.last_modified_at IS 'When the record was was last modified at';
+COMMENT ON COLUMN notification_filters.last_modified_by IS 'The user that last modified the record';
+
+GRANT SELECT ON notification_filters TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON notification_filters TO admin;

--- a/tables/v1/notification_rules.sql
+++ b/tables/v1/notification_rules.sql
@@ -1,0 +1,31 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE IF NOT EXISTS notification_rules (
+    fact_type_id      INTEGER                   NOT NULL,
+    integration_name  TEXT                      NOT NULL,
+    notification_name TEXT                      NOT NULL,
+    pattern           TEXT                      NOT NULL,
+    created_at        TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    created_by        TEXT                      NOT NULL  DEFAULT 'system',
+    last_modified_at  TIMESTAMP WITH TIME ZONE,
+    last_modified_by  TEXT,
+    PRIMARY KEY (fact_type_id, integration_name, notification_name),
+    FOREIGN KEY (fact_type_id) REFERENCES project_fact_types (id) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (integration_name, notification_name)
+            REFERENCES integration_notifications (integration_name, notification_name)
+            ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+COMMENT ON TABLE notification_rules IS 'Fact update rules for notifications from Integrated Applications';
+
+COMMENT ON COLUMN notification_rules.fact_type_id IS 'ID of the project fact to update';
+COMMENT ON COLUMN notification_rules.integration_name IS 'Name of the integrated application that sends the notification';
+COMMENT ON COLUMN notification_rules.notification_name IS 'Name of the notification this rule applies to';
+COMMENT ON COLUMN notification_rules.pattern IS 'JSON pointer to the value in the notification to use as the fact value';
+COMMENT ON COLUMN notification_rules.created_at IS 'When the record was created at';
+COMMENT ON COLUMN notification_rules.created_by IS 'The user that created the record';
+COMMENT ON COLUMN notification_rules.last_modified_at IS 'When the record was was last modified at';
+COMMENT ON COLUMN notification_rules.last_modified_by IS 'The user that last modified the record';
+
+GRANT SELECT ON notification_rules TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON notification_rules TO admin;

--- a/tests/test_integration_notifications.sql
+++ b/tests/test_integration_notifications.sql
@@ -1,0 +1,98 @@
+BEGIN;
+
+SELECT plan(27);
+
+-- fixtures
+SELECT lives_ok($$INSERT INTO v1.project_types (id, name, plural_name, created_by, slug)
+                  VALUES (1, 'test_project_type', 'tests', 'test_user', 'test_slug')$$,
+                'create project type');
+SELECT lives_ok($$INSERT INTO v1.project_fact_types (id, name, project_type_ids, created_by)
+                  VALUES (1, 'test_project_fact_type', ARRAY[1], 'test_user')$$,
+                'create project fact type');
+SELECT lives_ok($$INSERT INTO v1.integrations (name, api_endpoint)
+                  VALUES ('integration-1', 'https://example.com/integration-1')$$,
+                'create first integration');
+
+-- functionality tests
+SELECT lives_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                  VALUES ('integration-1', 'notification-1', '/id')$$,
+                'create valid integration notification');
+
+SELECT ok(created_at IS NOT NULL, 'created_at is NOT NULL for the new notification')
+  FROM v1.integration_notifications
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(created_by IS NOT NULL, 'created_by is NOT NULL for the new notification')
+  FROM v1.integration_notifications
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(last_modified_at IS NULL, 'last_modified_at is NULL for the new notification')
+  FROM v1.integration_notifications
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(last_modified_by IS NULL, 'last_modified_by is NULL for the new notification')
+  FROM v1.integration_notifications
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(documentation IS NULL, 'documentation link is NULL for the new notification')
+  FROM v1.integration_notifications
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(verification_token IS NULL, 'verification_token is NULL for the new notification')
+  FROM v1.integration_notifications
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(default_action = 'process', 'default for a new notification is to process the notification')
+  FROM v1.integration_notifications
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT throws_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                   VALUES ('integration-1', 'notification-1', '/id')$$,
+                 '23505', NULL, 'INSERT fails on duplicate');
+
+SELECT throws_ok($$INSERT INTO v1.integration_notifications (integration_name, id_pattern)
+                   VALUES ('integration-1', '/id')$$,
+                 '23502', NULL, 'INSERT fails without notification_name');
+
+SELECT throws_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name)
+                   VALUES ('integration-1', 'notification-1')$$,
+                 '23502', NULL, 'INSERT fails without id_pattern');
+
+SELECT throws_ok($$UPDATE v1.integration_notifications SET default_action = 'unknown-action-type'$$,
+                 '22P02', NULL, 'UPDATE fails with invalid default action');
+
+-- permission tests
+SET ROLE TO reader;
+SELECT lives_ok($$SELECT * FROM v1.integration_notifications$$, 'reader can read');
+SELECT throws_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                   VALUES ('integration-1', 'notification', '/id')$$, '42501', NULL, 'reader cannot insert');
+SELECT throws_ok($$UPDATE v1.integration_notifications SET id_pattern = '/id'$$, '42501', NULL, 'reader cannot update');
+SELECT throws_ok($$DELETE FROM v1.integration_notifications$$, '42501', NULL, 'reader cannot delete');
+
+SET ROLE TO writer;
+SELECT lives_ok($$SELECT * FROM v1.integration_notifications$$, 'writer can read');
+SELECT throws_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                   VALUES ('integration-1', 'notification', '/id')$$, '42501', NULL, 'writer cannot insert');
+SELECT throws_ok($$UPDATE v1.integration_notifications SET id_pattern = '/id'$$, '42501', NULL, 'writer cannot update');
+SELECT throws_ok($$DELETE FROM v1.integration_notifications$$, '42501', NULL, 'writer cannot delete');
+
+SET ROLE TO admin;
+SELECT lives_ok($$SELECT * FROM v1.integration_notifications$$, 'admin can read');
+SELECT lives_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                  VALUES ('integration-1', 'notification', '/id')$$, 'admin can insert');
+SELECT lives_ok($$UPDATE v1.integration_notifications
+                     SET id_pattern = '/id'
+                   WHERE notification_name = 'notification'$$, 'admin can update');
+SELECT lives_ok($$DELETE FROM v1.integration_notifications
+                   WHERE notification_name = 'notification'$$, 'admin can delete');
+
+SELECT *
+  FROM finish();
+ROLLBACK;

--- a/tests/test_notification_filters.sql
+++ b/tests/test_notification_filters.sql
@@ -1,0 +1,102 @@
+BEGIN;
+
+SELECT plan(28);
+
+-- fixtures
+SELECT lives_ok($$INSERT INTO v1.project_types (id, name, plural_name, created_by, slug)
+                  VALUES (1, 'test_project_type', 'tests', 'test_user', 'test_slug')$$,
+                'create project type');
+SELECT lives_ok($$INSERT INTO v1.project_fact_types (id, name, project_type_ids, created_by)
+                  VALUES (1, 'test_project_fact_type', ARRAY[1], 'test_user')$$,
+                'create project fact type');
+SELECT lives_ok($$INSERT INTO v1.integrations (name, api_endpoint)
+                  VALUES ('integration-1', 'https://example.com/integration-1')$$,
+                'create first integration');
+SELECT lives_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                  VALUES ('integration-1', 'notification-1', '/id')$$,
+                'create first notification');
+
+-- functionality tests
+SELECT lives_ok($$INSERT INTO v1.notification_filters (integration_name, notification_name, filter_name,
+                                                       pattern, operation, value, action)
+                  VALUES ('integration-1', 'notification-1', 'filter-1', '/enabled', '==', 'true', 'process')$$,
+                'create valid notification filter');
+SELECT throws_ok($$INSERT INTO v1.notification_filters (integration_name, notification_name, filter_name,
+                                                        pattern, operation, value, action)
+                   VALUES ('integration-1', 'notification-1', 'filter-1', '/enabled', '==', 'true', 'process')$$,
+                 '23505', NULL, 'INSERT fails on duplicate');
+
+SELECT lives_ok($$INSERT INTO v1.integrations (name, api_endpoint)
+                  VALUES ('integration-2', 'https://example.com/integration-2')$$,
+                'create temporary integration');
+SELECT lives_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                  VALUES ('integration-2', 'notification-2', '/id')$$,
+                'create temporary notification');
+SELECT lives_ok($$INSERT INTO v1.notification_filters (integration_name, notification_name, filter_name,
+                                                       pattern, operation, value, action)
+                  VALUES ('integration-2', 'notification-2', 'filter', '/enabled', '==', 'false', 'ignore')$$,
+                'create a temporary filter');
+
+SELECT lives_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                  VALUES ('integration-2', 'notification-3', '/id')$$,
+                'create another temporary notification');
+SELECT lives_ok($$INSERT INTO v1.notification_filters (integration_name, notification_name, filter_name,
+                                                       pattern, operation, value, action)
+                  VALUES ('integration-2', 'notification-3', 'filter', '/enabled', '!=', 'true', 'ignore')$$,
+                'create a temporary filter');
+
+SELECT lives_ok($$DELETE FROM v1.integration_notifications
+                   WHERE integration_name = 'integration-2'
+                     AND notification_name = 'notification-3'$$,
+                'deleting newest notification');
+
+SELECT ok(COUNT(*) = 0, 'Notification filter removed by cascade from integration_notifications')
+  FROM v1.notification_filters
+ WHERE integration_name = 'integration-2'
+   AND notification_name = 'notification-3';
+
+SELECT ok(COUNT(*) = 1, 'Unrelated notification filter not removed by cascade from integration_notifications')
+  FROM v1.notification_filters
+ WHERE integration_name = 'integration-2';
+
+SELECT lives_ok($$DELETE FROM v1.integrations WHERE name = 'integration-2'$$, 'deleting other notification');
+
+SELECT ok(COUNT(*) = 0, 'Notification filter removed by cascade from integrations')
+  FROM v1.notification_filters
+ WHERE integration_name = 'integration-2';
+
+-- permission tests
+SET ROLE TO reader;
+SELECT lives_ok($$SELECT * FROM v1.notification_filters$$, 'reader can read');
+SELECT throws_ok($$INSERT INTO v1.notification_filters (integration_name, notification_name, filter_name,
+                                                        pattern, operation, value, action)
+                   VALUES ('integration-1', 'notification-1', 'filter', '/id', '==', '112233', 'ignore')$$,
+                 '42501', NULL, 'reader cannot insert');
+SELECT throws_ok($$UPDATE v1.notification_filters SET filter_name = 'filter'$$, '42501', NULL, 'reader cannot update');
+SELECT throws_ok($$DELETE FROM v1.notification_filters$$, '42501', NULL, 'reader cannot delete');
+
+SET ROLE TO writer;
+SELECT lives_ok($$SELECT * FROM v1.notification_filters$$, 'writer can read');
+SELECT throws_ok($$INSERT INTO v1.notification_filters (integration_name, notification_name, filter_name,
+                                                        pattern, operation, value, action)
+                   VALUES ('integration-1', 'notification-1', 'filter', '/id', '==', '112233', 'ignore')$$,
+                 '42501', NULL, 'writer cannot insert');
+SELECT throws_ok($$UPDATE v1.notification_filters SET filter_name = 'filter'$$, '42501', NULL, 'writer cannot update');
+SELECT throws_ok($$DELETE FROM v1.notification_filters$$, '42501', NULL, 'writer cannot delete');
+
+SET ROLE TO admin;
+SELECT lives_ok($$SELECT * FROM v1.notification_filters$$, 'admin can read');
+SELECT lives_ok($$INSERT INTO v1.notification_filters (integration_name, notification_name, filter_name,
+                                                       pattern, operation, value, action)
+                  VALUES ('integration-1', 'notification-1', 'filter', '/id', '==', '112233', 'ignore')$$,
+                'admin can insert');
+SELECT lives_ok($$UPDATE v1.notification_filters
+                     SET filter_name = 'filter-3'
+                   WHERE filter_name = 'filter'$$, 'admin can update');
+SELECT lives_ok($$DELETE FROM v1.notification_filters
+                   WHERE filter_name = 'filter-3'$$, 'admin can delete');
+
+
+SELECT *
+  FROM finish();
+ROLLBACK;

--- a/tests/test_notification_rules.sql
+++ b/tests/test_notification_rules.sql
@@ -1,0 +1,129 @@
+BEGIN;
+
+SELECT plan(36);
+
+-- fixtures
+SELECT lives_ok($$INSERT INTO v1.project_types (id, name, plural_name, created_by, slug)
+                  VALUES (1, 'project-type', 'tests', 'test_user', 'test_slug')$$,
+                'create project type');
+SELECT lives_ok($$INSERT INTO v1.project_fact_types (id, name, project_type_ids, created_by)
+                  VALUES (1, 'first-fact-type', ARRAY[1], 'test_user')$$,
+                'create project fact type');
+SELECT lives_ok($$INSERT INTO v1.project_fact_types (id, name, project_type_ids, created_by)
+                  VALUES (2, 'second-fact-type', ARRAY[1], 'test_user')$$,
+                'Create another project fact type');
+SELECT lives_ok($$INSERT INTO v1.integrations (name, api_endpoint)
+                  VALUES ('integration-1', 'https://example.com/integration-1')$$,
+                'create first integration');
+SELECT lives_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                  VALUES ('integration-1', 'notification-1', '/id')$$,
+                'create first notification');
+
+-- functionality tests
+SELECT lives_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, notification_name, pattern)
+                  VALUES (1, 'integration-1', 'notification-1', '/id')$$, 'Insert valid notification rule');
+
+SELECT ok(created_at IS NOT NULL, 'created_at is NOT NULL for the new notification rule')
+  FROM v1.notification_rules
+ WHERE fact_type_id = 1
+   AND integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(created_by IS NOT NULL, 'created_by is NOT NULL for the new notification rule')
+  FROM v1.notification_rules
+ WHERE fact_type_id = 1
+   AND integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(last_modified_at IS NULL, 'last_modified_at is NULL for the new notification rule')
+  FROM v1.notification_rules
+ WHERE fact_type_id = 1
+   AND integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+SELECT ok(last_modified_by IS NULL, 'last_modified_by is NULL for the new notification rule')
+  FROM v1.notification_rules
+ WHERE fact_type_id = 1
+   AND integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+
+SELECT throws_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, notification_name, pattern)
+                   VALUES (1, 'integration-1', 'notification-1', '/id')$$,
+                 '23505', NULL, 'INSERT fails on duplicate');
+
+SELECT throws_ok($$INSERT INTO v1.notification_rules (integration_name, notification_name, pattern)
+                   VALUES ('integration-1', 'notification-1', '/id')$$,
+                 '23502', NULL, 'INSERT fails without fact_type_id');
+
+SELECT throws_ok($$INSERT INTO v1.notification_rules (fact_type_id, notification_name, pattern)
+                   VALUES (1, 'notification-1', '/id')$$,
+                 '23502', NULL, 'INSERT fails without integration_name');
+
+SELECT throws_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, pattern)
+                   VALUES (1, 'notification-1', '/id')$$,
+                 '23502', NULL, 'INSERT fails without notification_name');
+
+SELECT throws_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, notification_name)
+                   VALUES (1, 'integration-1', 'notification-1')$$,
+                 '23502', NULL, 'INSERT fails without pattern');
+
+SELECT lives_ok($$INSERT INTO v1.project_fact_types (id, name, project_type_ids, created_by)
+                  VALUES (3, 'third-fact-type', ARRAY[1], 'test_user')$$,
+                'Create another project fact type');
+SELECT lives_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, notification_name, pattern)
+                  VALUES (3, 'integration-1', 'notification-1', '/id')$$,
+                'Insert another notification rule');
+SELECT lives_ok($$DELETE FROM v1.project_fact_types WHERE id = 3$$, 'Delete new project fact type');
+SELECT ok(COUNT(*) = 0, 'Delete cascades from project_fact_types')
+  FROM v1.notification_rules
+ WHERE fact_type_id = 3;
+
+SELECT lives_ok($$INSERT INTO v1.integration_notifications (integration_name, notification_name, id_pattern)
+                  VALUES ('integration-1', 'notification-2', '/id')$$,
+                'Create another notification');
+SELECT lives_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, notification_name, pattern)
+                  VALUES (1, 'integration-1', 'notification-2', '/id')$$,
+                'Insert another notification rule');
+SELECT lives_ok($$DELETE FROM v1.integration_notifications
+                   WHERE integration_name = 'integration-1'
+                     AND notification_name = 'notification-2'$$,
+                'Delete new notification');
+SELECT ok(COUNT(*) = 0, 'Delete cascades from integration_notifications')
+  FROM v1.notification_rules
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-2';
+SELECT ok(COUNT(*) = 1, 'Delete does not cascade from integration_notifications to other rules')
+  FROM v1.notification_rules
+ WHERE integration_name = 'integration-1'
+   AND notification_name = 'notification-1';
+
+-- permission tests
+SET ROLE TO reader;
+SELECT lives_ok($$SELECT * FROM v1.notification_rules$$, 'reader can read');
+SELECT throws_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, notification_name, pattern)
+                   VALUES (1, 'integration-1', 'notification-1', '/id')$$, '42501', NULL, 'reader cannot insert');
+SELECT throws_ok($$UPDATE v1.notification_rules SET fact_type_id = 1 WHERE fact_type_id = 1$$,
+                 '42501', NULL, 'reader cannot update');
+SELECT throws_ok($$DELETE FROM v1.notification_rules WHERE fact_type_id = 9999$$,
+                 '42501', NULL, 'reader cannot delete');
+
+SET ROLE TO writer;
+SELECT lives_ok($$SELECT * FROM v1.notification_rules$$, 'writer can read');
+SELECT throws_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, notification_name, pattern)
+                   VALUES (1, 'integration-1', 'notification-1', '/id')$$, '42501', NULL, 'writer cannot insert');
+SELECT throws_ok($$UPDATE v1.notification_rules SET fact_type_id = 1 WHERE fact_type_id = 1$$,
+                 '42501', NULL, 'writer cannot update');
+SELECT throws_ok($$DELETE FROM v1.notification_rules WHERE fact_type_id = 9999$$,
+                 '42501', NULL, 'writer cannot delete');
+
+SET ROLE TO admin;
+SELECT lives_ok($$SELECT * FROM v1.notification_rules$$, 'admin can read');
+SELECT lives_ok($$INSERT INTO v1.notification_rules (fact_type_id, integration_name, notification_name, pattern)
+                   VALUES (2, 'integration-1', 'notification-1', '/id')$$, 'admin can insert');
+SELECT lives_ok($$UPDATE v1.notification_rules SET fact_type_id = 1 WHERE fact_type_id = 1$$, 'admin can update');
+SELECT lives_ok($$DELETE FROM v1.notification_rules WHERE fact_type_id = 2$$, 'admin can delete');
+
+SELECT *
+  FROM finish();
+ROLLBACK;

--- a/types/v1/notification_action_type.sql
+++ b/types/v1/notification_action_type.sql
@@ -1,0 +1,5 @@
+SET search_path=v1;
+
+CREATE TYPE notification_action_type AS ENUM ('ignore', 'process');
+
+COMMENT ON TYPE notification_action_type IS 'Used to indicate the action type for a notification or field';

--- a/types/v1/notification_filter_operation_type.sql
+++ b/types/v1/notification_filter_operation_type.sql
@@ -1,0 +1,5 @@
+SET search_path=v1;
+
+CREATE TYPE notification_filter_operation_type AS ENUM ('==', '!=');
+
+COMMENT ON TYPE notification_filter_operation_type IS 'Used to indicate the comparison operation for a notification filter';


### PR DESCRIPTION
This PR adds the tables that power notification processing. The API uses this set of tables to control how it processes incoming webhook notifications from connected applications. There are three new entities being added:

* **notifications** are a name for a set of filters and rules that are applied to the request body. The notification also defines where in the request body to retrieve the surrogate ID for an Imbi project
* **filters** are responsible for deciding whether a notification should be processed by inspecting the request body
* **rules** define the data to extract from a notification body and which Imbi facts to assign the data to

The processing logic will look something like:

1. retrieve the notification definition by integration name & notification name -- _if not found, then ignore the notification_
2. retrieve the list of filters for the incoming notification
3. evaluate each filters using the request body as input and decide whether the notification should be ignored or processed
4. extract the surrogate ID from the request body using information from the notification
5. look up the Imbi project using the integration name & surrogate ID -- _if not found, then ignore the notification_
6. create a list of updates using the rules and the request body -- _the output is a list of `(project-type-id, value)`_
7. remove updates with project-type-ids that are not applicable to the Imbi project
8. update the Imbi project facts for the project

There is a good bit of nuance in step 3 but that will be explained in code eventually. The following is a rough ERD for what the SQL should be building. The `integrations` and `integration_identifiers` tables were created in #16.

```mermaid
erDiagram
    integrations {
        string name PK
    }
    integration_notifications {
        string integration_name PK,FK
        string notification_name PK
    }
    notification_filters {
        string integration_name PK,FK
        string notification_name PK,FK
        string filter_name PK
    }
    notification_rules {
        string integration_name PK,FK
        string notification_name PK,FK
        int fact_type_id PK,FK
    }
    project_identifiers {
        string integration_name PK
        int project_id PK,FK
        string external_id
    }

    integrations ||--o{ integration_notifications : sends
    integration_notifications ||--o{ notification_filters : filtered-by
    integration_notifications ||--|{ notification_rules : extraction-definitions
    notification_rules }o--|| project_fact_types : fact-type
    project ||--o{ project_identifiers : identified-by
    project ||--o{ project_facts : ""
    project_facts }o--|| project_fact_types : ""
```