### PR TITLE
Touch up OAuth 2.0 schema

### DIFF
--- a/tables/v1/user_oauth2_tokens.sql
+++ b/tables/v1/user_oauth2_tokens.sql
@@ -4,6 +4,7 @@ CREATE TABLE v1.user_oauth2_tokens (
     external_id TEXT NOT NULL,
     access_token TEXT NOT NULL,
     refresh_token TEXT NOT NULL,
+    id_token TEXT,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (integration, external_id)
 );

--- a/tables/v1/user_oauth2_tokens.sql
+++ b/tables/v1/user_oauth2_tokens.sql
@@ -3,7 +3,7 @@ CREATE TABLE v1.user_oauth2_tokens (
     integration TEXT NOT NULL REFERENCES v1.oauth2_integrations(name) ON DELETE RESTRICT ON UPDATE CASCADE,
     external_id TEXT NOT NULL,
     access_token TEXT NOT NULL,
-    refresh_token TEXT NOT NULL,
+    refresh_token TEXT,
     id_token TEXT,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (integration, external_id)


### PR DESCRIPTION
Adds optional OIDC tokens, and also makes refresh tokens optional, as they are in the OAuth 2.0 spec.