### PR TITLE
Add Configuration tables for AWS SSM

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,7 @@ schemata/v1.sql
 -- Types
 types/v1/automation_category_type.sql
 types/v1/change_type.sql
+types/v1/configuration_type.sql
 types/v1/cookie_cutter_type.sql
 types/v1/data_type.sql
 types/v1/entity_type.sql

--- a/MANIFEST
+++ b/MANIFEST
@@ -28,6 +28,7 @@ tables/v1/namespace_kpi_history.sql
 tables/v1/integrations.sql
 tables/v1/automations.sql
 tables/v1/automations_graph.sql
+tables/v1/aws_roles.sql
 tables/v1/integration_notifications.sql
 tables/v1/notification_filters.sql
 tables/v1/oauth2_integrations.sql

--- a/tables/v1/aws_roles.sql
+++ b/tables/v1/aws_roles.sql
@@ -1,0 +1,24 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE IF NOT EXISTS aws_roles (
+    role_arn      TEXT                      NOT NULL,
+    environment   TEXT                      NOT NULL,
+    namespace_id  INTEGER                   NOT NULL,
+    created_at    TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    created_by    TEXT                      NOT NULL,
+    PRIMARY KEY (role_arn, environment, namespace_id),
+    UNIQUE (environment, namespace_id),
+    FOREIGN KEY (environment) REFERENCES environments (name) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (namespace_id) REFERENCES namespaces (id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+COMMENT ON TABLE aws_roles IS 'AWS roles with permissions in the given environment and namespace';
+
+COMMENT ON COLUMN aws_roles.role_arn IS 'AWS ARN of the role';
+COMMENT ON COLUMN aws_roles.environment IS 'Name of the environment this role is associated with';
+COMMENT ON COLUMN aws_roles.namespace_id IS 'ID of the namespace this role is associated with';
+COMMENT ON COLUMN aws_roles.created_at IS 'When the record was created at';
+COMMENT ON COLUMN aws_roles.created_by IS 'The user that created the record';
+
+GRANT SELECT ON aws_roles TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON aws_roles TO admin;

--- a/tables/v1/namespaces.sql
+++ b/tables/v1/namespaces.sql
@@ -11,7 +11,9 @@ CREATE TABLE IF NOT EXISTS namespaces (
   icon_class        TEXT                      NOT NULL,
   maintained_by     TEXT[],
   gitlab_group_name TEXT,
-  sentry_team_slug  TEXT);
+  sentry_team_slug  TEXT,
+  aws_ssm_slug      TEXT
+);
 
 COMMENT ON TABLE namespaces IS 'Organizational Teams';
 COMMENT ON COLUMN namespaces.id IS 'Surrogate key for URLs and linking';
@@ -25,6 +27,7 @@ COMMENT ON COLUMN namespaces.icon_class IS 'Font Awesome UI icon class';
 COMMENT ON COLUMN namespaces.maintained_by IS 'Optional groups that have access to modify projects in the namespace';
 COMMENT ON COLUMN namespaces.gitlab_group_name IS 'Optional name of the corresponding group in GitLab';
 COMMENT ON COLUMN namespaces.sentry_team_slug IS 'Optional name of the corresponding team in Sentry';
+COMMENT ON COLUMN namespaces.aws_ssm_slug IS 'Optional name of the corresponding team in the AWS SSM path prefix';
 
 GRANT SELECT ON namespaces TO reader;
 GRANT SELECT, INSERT, UPDATE, DELETE ON namespaces TO admin;

--- a/tables/v1/projects.sql
+++ b/tables/v1/projects.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS projects (
   sentry_project_slug    TEXT,
   sonarqube_project_key  TEXT,
   pagerduty_service_id   TEXT,
+  configuration_type     configuration_type,
   UNIQUE (namespace_id, project_type_id, name),
   FOREIGN KEY (namespace_id) REFERENCES namespaces (id) ON UPDATE CASCADE ON DELETE RESTRICT,
   FOREIGN KEY (project_type_id) REFERENCES project_types (id) ON UPDATE CASCADE ON DELETE RESTRICT
@@ -41,6 +42,7 @@ COMMENT ON COLUMN projects.gitlab_project_id IS 'If set, specifies the GitLab pr
 COMMENT ON COLUMN projects.sentry_project_slug IS 'If set, specifies the project slug for the Sentry integration';
 COMMENT ON COLUMN projects.sonarqube_project_key IS 'If set, specifies the project slug for the SonarQube integration';
 COMMENT ON COLUMN projects.pagerduty_service_id IS 'If set, specifies the service id for the PagerDuty integration';
+COMMENT ON COLUMN projects.configuration_type IS 'If set, specifies which configuration system the project uses';
 
 GRANT SELECT ON projects TO reader;
 GRANT SELECT, INSERT, UPDATE, DELETE ON projects TO writer;

--- a/types/v1/configuration_type.sql
+++ b/types/v1/configuration_type.sql
@@ -1,0 +1,5 @@
+SET search_path=v1;
+
+CREATE TYPE configuration_type AS ENUM ('ssm');
+
+COMMENT ON TYPE configuration_type IS 'Used to indicate the configuration system of a project';


### PR DESCRIPTION
This adds:
- an enum to enumerate viable configuration types we plan on supporting, starting for now with just `ssm`
- The nullable `configuration_type` column to the `v1.projects` table, which will map those configuration enum values to the project, so that the UI can dynamically know which endpoint to fetch config from and how to display it
- The `v1.aws_roles` table, which will specify AWS roles that have permissions in the given namespace,environment pair, which will be assumed by users and used to authenticate to perform various actions in AWS