### PR TITLE
Add namespaces.pagerduty_policy

### DIFF
--- a/tables/v1/namespaces.sql
+++ b/tables/v1/namespaces.sql
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS namespaces (
   maintained_by     TEXT[],
   gitlab_group_name TEXT,
   sentry_team_slug  TEXT,
-  aws_ssm_slug      TEXT
+  aws_ssm_slug      TEXT,
+  pagerduty_policy  TEXT
 );
 
 COMMENT ON TABLE namespaces IS 'Organizational Teams';
@@ -28,6 +29,7 @@ COMMENT ON COLUMN namespaces.maintained_by IS 'Optional groups that have access 
 COMMENT ON COLUMN namespaces.gitlab_group_name IS 'Optional name of the corresponding group in GitLab';
 COMMENT ON COLUMN namespaces.sentry_team_slug IS 'Optional name of the corresponding team in Sentry';
 COMMENT ON COLUMN namespaces.aws_ssm_slug IS 'Optional name of the corresponding team in the AWS SSM path prefix';
+COMMENT ON COLUMN namespaces.pagerduty_policy IS 'Optional ID of the PagerDuty escalation policy for this team ';
 
 GRANT SELECT ON namespaces TO reader;
 GRANT SELECT, INSERT, UPDATE, DELETE ON namespaces TO admin;


### PR DESCRIPTION
This PR adds a column to `v1.namespaces` to store the PagerDuty escalation policy ID. This is required to create PagerDuty services as part of https://github.com/AWeber-Imbi/imbi/issues/15.