### PR TITLE
Add component-related tables

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -25,6 +25,7 @@ types/v1/notification_filter_operation_type.sql
 
 -- Tables
 tables/v1/components.sql
+tables/v1/component_versions.sql
 tables/v1/environments.sql
 tables/v1/namespaces.sql
 tables/v1/namespace_kpi_history.sql

--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,7 @@ schemata/v1.sql
 -- Types
 types/v1/automation_category_type.sql
 types/v1/change_type.sql
+types/v1/component_status_type.sql
 types/v1/configuration_type.sql
 types/v1/cookie_cutter_type.sql
 types/v1/data_type.sql
@@ -23,6 +24,7 @@ types/v1/notification_action_type.sql
 types/v1/notification_filter_operation_type.sql
 
 -- Tables
+tables/v1/components.sql
 tables/v1/environments.sql
 tables/v1/namespaces.sql
 tables/v1/namespace_kpi_history.sql

--- a/MANIFEST
+++ b/MANIFEST
@@ -41,6 +41,7 @@ tables/v1/available_automations.sql
 tables/v1/cookie_cutters.sql
 tables/v1/projects.sql
 tables/v1/operations_log.sql
+tables/v1/project_components.sql
 tables/v1/project_dependencies.sql
 tables/v1/project_fact_types.sql
 tables/v1/project_fact_type_enums.sql

--- a/Makefile
+++ b/Makefile
@@ -9,39 +9,39 @@ build:
 	@ mkdir -p build
 
 clean:
-	@ docker-compose down --volumes --remove-orphans
+	@ docker compose down --volumes --remove-orphans
 	@ rm -rf build
 
 ready: build
-ifeq ($(shell docker-compose ps postgres |grep -c healthy), 0)
+ifeq ($(shell docker compose ps postgres |grep -c healthy), 0)
 	@ $(error Docker image for PostgreSQL is not running, perhaps you forget to run "make bootstrap" or you should "make clean" and try again)
 endif
 
 test: ready
 	@ echo "Creating test schema"
-	@ docker-compose exec -T postgres /usr/bin/dropdb --if-exists ${REVISION} > /dev/null
-	@ docker-compose exec -T postgres /usr/bin/createdb ${REVISION} > /dev/null
+	@ docker compose exec -T postgres /usr/bin/dropdb --if-exists ${REVISION} > /dev/null
+	@ docker compose exec -T postgres /usr/bin/createdb ${REVISION} > /dev/null
 	@ bin/build.sh build/ddl-${REVISION}.sql build/dml-${REVISION}.sql
 	@ sleep 1
-	@ docker-compose exec -T postgres /usr/bin/psql -d ${REVISION} -f /build/ddl-${REVISION}.sql -X -v ON_ERROR_STOP=1 -q --pset=pager=off
-	@ docker-compose exec -T postgres /usr/bin/psql -d ${REVISION} -f /build/dml-${REVISION}.sql -X -v ON_ERROR_STOP=1 -q --pset=pager=off
-	@ docker-compose exec -T postgres /usr/bin/psql -d ${REVISION} -c "CREATE EXTENSION pgtap;" -X -q --pset=pager=off
-	@ docker-compose exec -T postgres /usr/bin/psql -d ${REVISION} -c "CREATE EXTENSION plpgsql_check;" -X -q --pset=pager=off
+	@ docker compose exec -T postgres /usr/bin/psql -d ${REVISION} -f /build/ddl-${REVISION}.sql -X -v ON_ERROR_STOP=1 -q --pset=pager=off
+	@ docker compose exec -T postgres /usr/bin/psql -d ${REVISION} -f /build/dml-${REVISION}.sql -X -v ON_ERROR_STOP=1 -q --pset=pager=off
+	@ docker compose exec -T postgres /usr/bin/psql -d ${REVISION} -c "CREATE EXTENSION pgtap;" -X -q --pset=pager=off
+	@ docker compose exec -T postgres /usr/bin/psql -d ${REVISION} -c "CREATE EXTENSION plpgsql_check;" -X -q --pset=pager=off
 	@ echo "Running pgTAP Tests"
-	@ docker-compose exec -T postgres /usr/local/bin/pg_prove -v -f -d ${REVISION} tests/*.sql
-	@ docker-compose exec -T postgres /usr/bin/dropdb ${REVISION} > /dev/null || true
+	@ docker compose exec -T postgres /usr/local/bin/pg_prove -v -f -d ${REVISION} tests/*.sql
+	@ docker compose exec -T postgres /usr/bin/dropdb ${REVISION} > /dev/null || true
 	@ rm build/d*l-${REVISION}.sql
 
 install: ready
 	@ echo "Creating schema"
-	@ docker-compose exec -T postgres /usr/bin/dropdb --if-exists imbi > /dev/null
-	@ docker-compose exec -T postgres /usr/bin/createdb imbi > /dev/null
+	@ docker compose exec -T postgres /usr/bin/dropdb --if-exists imbi > /dev/null
+	@ docker compose exec -T postgres /usr/bin/createdb imbi > /dev/null
 	@ bin/build.sh build/ddl-imbi.sql build/dml-imbi.sql
 	@ sleep 1
-	@ docker-compose exec -T postgres /usr/bin/psql -d imbi -f /build/ddl-imbi.sql -X -v ON_ERROR_STOP=1 -q --pset=pager=off
-	@ docker-compose exec -T postgres /usr/bin/psql -d imbi -f /build/dml-imbi.sql -X -v ON_ERROR_STOP=1 -q --pset=pager=off
-	@ docker-compose exec -T postgres /usr/bin/psql -d imbi -c "CREATE EXTENSION pgtap;" -X -q --pset=pager=off
-	@ docker-compose exec -T postgres /usr/bin/psql -d imbi -c "CREATE EXTENSION plpgsql_check;" -X -q --pset=pager=off
+	@ docker compose exec -T postgres /usr/bin/psql -d imbi -f /build/ddl-imbi.sql -X -v ON_ERROR_STOP=1 -q --pset=pager=off
+	@ docker compose exec -T postgres /usr/bin/psql -d imbi -f /build/dml-imbi.sql -X -v ON_ERROR_STOP=1 -q --pset=pager=off
+	@ docker compose exec -T postgres /usr/bin/psql -d imbi -c "CREATE EXTENSION pgtap;" -X -q --pset=pager=off
+	@ docker compose exec -T postgres /usr/bin/psql -d imbi -c "CREATE EXTENSION plpgsql_check;" -X -q --pset=pager=off
 	@ rm build/d*l-imbi.sql
 	@ echo "Schema installed into imbi"
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   postgres:
     image: gavinmroy/alpine-postgres:13.2-0

--- a/tables/v1/component_versions.sql
+++ b/tables/v1/component_versions.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS v1.component_versions
     package_url TEXT          NOT NULL,
     version     TEXT          NOT NULL,
     PRIMARY KEY (package_url, version),
+    UNIQUE (package_url, id),
     FOREIGN KEY (package_url) REFERENCES v1.components (package_url) ON DELETE CASCADE ON UPDATE CASCADE
 );
 

--- a/tables/v1/component_versions.sql
+++ b/tables/v1/component_versions.sql
@@ -1,0 +1,20 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE IF NOT EXISTS v1.component_versions
+(
+    id          SERIAL UNIQUE NOT NULL,
+    package_url TEXT          NOT NULL,
+    version     TEXT          NOT NULL,
+    PRIMARY KEY (package_url, version),
+    FOREIGN KEY (package_url) REFERENCES v1.components (package_url) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+COMMENT ON TABLE v1.component_versions IS 'Versions of a component that are/were in use by a project';
+COMMENT ON COLUMN v1.component_versions.id IS 'Surrogate identifier for the version';
+COMMENT ON COLUMN v1.component_versions.package_url IS 'Identifies the component (FK v1.components.package_url)';
+COMMENT ON COLUMN v1.component_versions.version IS 'Version of the component bound to the surrogate ID';
+
+GRANT SELECT ON v1.component_versions TO reader;
+GRANT SELECT ON v1.component_versions TO writer;
+GRANT SELECT, INSERT, UPDATE, DELETE ON v1.component_versions TO admin;
+GRANT USAGE, SELECT, UPDATE ON SEQUENCE v1.component_versions_id_seq TO admin;

--- a/tables/v1/components.sql
+++ b/tables/v1/components.sql
@@ -1,0 +1,31 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE IF NOT EXISTS v1.components
+(
+    package_url      TEXT                     NOT NULL PRIMARY KEY,
+    name             TEXT                     NOT NULL,
+    status           component_status_type    NOT NULL DEFAULT 'Active',
+    home_page        TEXT,
+    icon_class       TEXT                              DEFAULT 'fas fa-save',
+    active_version   TEXT                              DEFAULT NULL,
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by       TEXT                     NOT NULL,
+    last_modified_by TEXT,
+    last_modified_at TIMESTAMP WITH TIME ZONE
+);
+
+COMMENT ON TABLE v1.components IS 'Software that Imbi projects use / depend on / bundle';
+COMMENT ON COLUMN v1.components.package_url IS 'Uniquely identifies the component. This is a Package URL (purl) without a version component';
+COMMENT ON COLUMN v1.components.name IS 'Human-readable name of this component';
+COMMENT ON COLUMN v1.components.status IS 'Global status for all versions of this component';
+COMMENT ON COLUMN v1.components.home_page IS 'Optional home page for this component';
+COMMENT ON COLUMN v1.components.icon_class IS 'Font Awesome UI icon class';
+COMMENT ON COLUMN v1.components.active_version IS 'Version expression for the "active" version of this component. This is a sem-ver range if the first character is a tilde or caret; otherwise, it is an exact version string';
+COMMENT ON COLUMN v1.components.created_at IS 'When was this component added';
+COMMENT ON COLUMN v1.components.created_by IS 'Who added this component';
+COMMENT ON COLUMN v1.components.last_modified_at IS 'When was this component last modified';
+COMMENT ON COLUMN v1.components.last_modified_by IS 'Who modified this component last';
+
+GRANT SELECT ON v1.components TO reader;
+GRANT SELECT ON v1.components TO writer;
+GRANT SELECT, INSERT, UPDATE, DELETE ON v1.components TO admin;

--- a/tables/v1/project_components.sql
+++ b/tables/v1/project_components.sql
@@ -1,0 +1,20 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE v1.project_components
+(
+    project_id INTEGER NOT NULL,
+    package_url TEXT NOT NULL,
+    version_id INTEGER NOT NULL,
+    PRIMARY KEY (project_id, version_id),
+    FOREIGN KEY (project_id) REFERENCES v1.projects (id) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (package_url, version_id) REFERENCES v1.component_versions (package_url, id) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+COMMENT ON TABLE v1.project_components IS 'Component versions for the active version of a project';
+COMMENT ON COLUMN v1.project_components.project_id IS 'Project that includes this component version';
+COMMENT ON COLUMN v1.project_components.package_url IS 'Identifies the component';
+COMMENT ON COLUMN v1.project_components.version_id IS 'Identifies the distinct version of the component';
+
+GRANT SELECT ON v1.project_components TO reader;
+GRANT SELECT ON v1.project_components TO writer;
+GRANT SELECT, INSERT, UPDATE, DELETE ON v1.project_components TO admin;

--- a/tests/test_v1_component_versions.sql
+++ b/tests/test_v1_component_versions.sql
@@ -1,0 +1,49 @@
+BEGIN;
+
+SELECT plan(18);
+
+-- fixtures
+INSERT INTO v1.components(package_url, name, created_by)
+VALUES ('pkg:first', 'first package', 'me'),
+       ('pkg:second', 'second package', 'me');
+
+-- structural checks
+SELECT col_is_pk('v1', 'component_versions', ARRAY ['package_url', 'version'], '(package_url, version) is PK');
+SELECT fk_ok('v1', 'component_versions', 'package_url', 'v1', 'components', 'package_url', 'package_url is FK');
+SELECT col_is_unique('v1', 'component_versions', 'id', 'id is UNIQUE');
+
+-- functionality tests
+SELECT lives_ok($$INSERT INTO v1.component_versions(package_url, version)
+                  VALUES ('pkg:first', '1'),
+                         ('pkg:second', '1'), ('pkg:second', '2')$$);
+SELECT lives_ok($$DELETE FROM v1.components WHERE package_url = 'pkg:second'$$);
+SELECT results_eq($$SELECT COUNT(id)::INT AS c FROM v1.component_versions$$, ARRAY [1]);
+
+-- permission tests
+SET ROLE TO reader;
+SELECT lives_ok($$SELECT * FROM v1.component_versions$$, 'reader can read');
+SELECT throws_ok($$INSERT INTO v1.component_versions (package_url, version)
+                   VALUES ('pkg:first', '2')$$, '42501', NULL, 'reader cannot insert');
+SELECT throws_ok($$UPDATE v1.component_versions SET package_url = package_url$$,
+                 '42501', NULL, 'reader cannot update');
+SELECT throws_ok($$DELETE FROM v1.component_versions$$, '42501', NULL, 'reader cannot delete');
+
+SET ROLE TO writer;
+SELECT lives_ok($$SELECT * FROM v1.component_versions$$, 'writer can read');
+SELECT throws_ok($$INSERT INTO v1.component_versions (package_url, version)
+                   VALUES ('pkg:first', '2')$$, '42501', NULL, 'writer cannot insert');
+SELECT throws_ok($$UPDATE v1.component_versions SET package_url = package_url$$,
+                 '42501', NULL, 'writer cannot update');
+SELECT throws_ok($$DELETE FROM v1.component_versions$$, '42501', NULL, 'writer cannot delete');
+
+SET ROLE TO admin;
+SELECT lives_ok($$SELECT * FROM v1.component_versions$$, 'admin can read');
+SELECT lives_ok($$INSERT INTO v1.component_versions (package_url, version)
+                   VALUES ('pkg:first', '2')$$, 'admin can insert');
+SELECT lives_ok($$UPDATE v1.component_versions SET package_url = package_url$$, 'admin can update');
+SELECT lives_ok($$DELETE FROM v1.component_versions$$, 'admin can delete');
+
+
+SELECT *
+  FROM finish();
+ROLLBACK;

--- a/tests/test_v1_components.sql
+++ b/tests/test_v1_components.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+SELECT plan(13);
+
+-- structural tests
+SELECT col_is_pk('v1', 'components', 'package_url', 'PK IS (package_url)');
+
+-- permission tests
+SET ROLE TO reader;
+SELECT lives_ok($$SELECT * FROM v1.components$$, 'reader can read');
+SELECT throws_ok($$INSERT INTO v1.components (package_url, name, created_by)
+                   VALUES ('pkg:whatever', 'whatever', 'me')$$,
+                 '42501', NULL, 'reader cannot insert');
+SELECT throws_ok($$UPDATE v1.components SET name = name$$, '42501', NULL, 'reader cannot update');
+SELECT throws_ok($$DELETE FROM v1.components$$, '42501', NULL, 'reader cannot delete');
+
+SET ROLE TO writer;
+SELECT lives_ok($$SELECT * FROM v1.components$$, 'writer can read');
+SELECT throws_ok($$INSERT INTO v1.components (package_url, name, created_by)
+                   VALUES ('pkg:whatever', 'whatever', 'me')$$,
+                 '42501', NULL, 'writer cannot insert');
+SELECT throws_ok($$UPDATE v1.components SET name = name$$, '42501', NULL, 'writer cannot update');
+SELECT throws_ok($$DELETE FROM v1.components$$, '42501', NULL, 'writer cannot delete');
+
+SET ROLE TO admin;
+SELECT lives_ok($$SELECT * FROM v1.components$$, 'admin can read');
+SELECT lives_ok($$INSERT INTO v1.components (package_url, name, created_by)
+                  VALUES ('pkg:whatever', 'whatever', 'admin')$$, 'admin can write');
+SELECT lives_ok($$UPDATE v1.components SET name = name$$, 'admin can update');
+SELECT lives_ok($$DELETE FROM v1.components$$, 'admin can delete');
+
+SELECT *
+  FROM finish();
+ROLLBACK;

--- a/tests/test_v1_project_components.sql
+++ b/tests/test_v1_project_components.sql
@@ -1,0 +1,100 @@
+BEGIN;
+
+SELECT plan(26);
+
+-- fixtures
+INSERT INTO v1.namespaces(id, created_by, name, slug, icon_class)
+VALUES (1, 'test', 'Namespace', 'namespace', 'whatever');
+INSERT INTO v1.project_types(id, created_by, name, plural_name, slug)
+VALUES (1, 'test', 'Project Type', 'Project Types', 'project-type');
+INSERT INTO v1.projects(id, namespace_id, project_type_id, created_by, name, slug)
+VALUES (1, 1, 1, 'test', 'Some Project', 'some-project'),
+       (2, 1, 1, 'test', 'Another Project', 'another-project');
+INSERT INTO v1.components(package_url, name, created_by)
+VALUES ('pkg:1', 'Component 1', 'me'),
+       ('pkg:2', 'Component 2', 'me');
+INSERT INTO v1.component_versions(id, package_url, version)
+VALUES (1, 'pkg:1', '1.0.0'),
+       (2, 'pkg:2', '2.0.0'),
+       (3, 'pkg:1', '1.1.0');
+
+INSERT INTO v1.project_components(project_id, package_url, version_id)
+VALUES (1, 'pkg:1', 1),
+       (1, 'pkg:2', 2);
+
+-- structural tests
+SELECT col_is_pk('v1', 'project_components', ARRAY ['project_id', 'version_id'], 'PK is (project_id, version_id)');
+SELECT fk_ok('v1', 'project_components', 'project_id', 'v1', 'projects', 'id', 'project_id is FK to projects');
+SELECT fk_ok('v1', 'project_components', ARRAY ['package_url', 'version_id'],
+             'v1', 'component_versions', ARRAY ['package_url', 'id'],
+             '(package_url, version_id) is FK to component_versions');
+
+-- functionality tests
+SELECT lives_ok($$UPDATE v1.component_versions
+                     SET id = 0
+                   WHERE id = 1$$, 'updated component version id');
+SELECT results_eq($$SELECT project_id, version_id
+                      FROM v1.project_components
+                     ORDER BY version_id$$,
+                  $$VALUES (1, 0), (1, 2)$$,
+                  'component version id update cascaded');
+SELECT lives_ok($$UPDATE v1.projects
+                     SET id = 0
+                   WHERE id = 1$$, 'updated project_id');
+SELECT results_eq($$SELECT project_id, version_id
+                      FROM v1.project_components
+                     ORDER BY version_id$$,
+                  $$VALUES (0, 0), (0, 2)$$,
+                  'project id update cascaded');
+SELECT lives_ok($$UPDATE v1.components
+                     SET package_url = 'pkg:3'
+                   WHERE package_url = 'pkg:2'$$,
+                'component package_url updated');
+SELECT results_eq($$SELECT project_id, version_id
+                      FROM v1.project_components
+                     WHERE package_url = 'pkg:3'$$,
+                  $$VALUES (0, 2)$$,
+                  'component package_url update cascaded');
+SELECT throws_ok($$DELETE FROM v1.components WHERE package_url = 'pkg:3'$$,
+                 '23503', NULL, 'cannot delete component with active versions');
+SELECT lives_ok($$DELETE FROM v1.project_components
+                   WHERE version_id IN (SELECT id
+                                          FROM v1.component_versions
+                                         WHERE package_url = 'pkg:3')$$,
+                'remove active version(s) for package');
+SELECT lives_ok($$DELETE FROM v1.components WHERE package_url = 'pkg:3'$$,
+                'delete component without active versions');
+SELECT lives_ok($$DELETE FROM v1.projects WHERE id = 0$$, 'deleted project');
+SELECT results_eq($$SELECT COUNT(*)::INTEGER FROM v1.project_components$$, ARRAY [0],
+                  'delete cascaded to project_components');
+
+-- permission tests
+SET ROLE TO reader;
+SELECT lives_ok($$SELECT * FROM v1.project_components$$, 'reader can read');
+SELECT throws_ok($$INSERT INTO v1.project_components (project_id, package_url, version_id)
+                   VALUES (0, 'pkg:1', 0)$$,
+                 '42501', NULL, 'reader cannot insert');
+SELECT throws_ok($$UPDATE v1.project_components SET version_id = version_id$$,
+                 '42501', NULL, 'reader cannot update');
+SELECT throws_ok($$DELETE FROM v1.project_components$$, '42501', NULL, 'reader cannot delete');
+
+SET ROLE TO writer;
+SELECT lives_ok($$SELECT * FROM v1.project_components$$, 'writer can read');
+SELECT throws_ok($$INSERT INTO v1.project_components (project_id, package_url, version_id)
+                   VALUES (0, 'pkg:1', 0)$$,
+                 '42501', NULL, 'writer cannot insert');
+SELECT throws_ok($$UPDATE v1.project_components SET version_id = version_id$$,
+                 '42501', NULL, 'writer cannot update');
+SELECT throws_ok($$DELETE FROM v1.project_components$$, '42501', NULL, 'writer cannot delete');
+
+SET ROLE TO admin;
+SELECT lives_ok($$SELECT * FROM v1.project_components$$, 'admin can read');
+SELECT lives_ok($$INSERT INTO v1.project_components (project_id, package_url, version_id)
+                  VALUES (2, 'pkg:1', 3)$$,
+                'admin can insert');
+SELECT lives_ok($$UPDATE v1.project_components SET version_id = version_id$$, 'admin can update');
+SELECT lives_ok($$DELETE FROM v1.project_components$$, 'admin can delete');
+
+SELECT *
+  FROM finish();
+ROLLBACK;

--- a/types/v1/component_status_type.sql
+++ b/types/v1/component_status_type.sql
@@ -1,0 +1,8 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TYPE component_status_type
+         AS ENUM ('Active',
+                  'Deprecated',
+                  'Forbidden');
+
+COMMENT ON TYPE v1.component_status_type IS 'Status of a software component regardless of version';


### PR DESCRIPTION
This PR adds the tables for representing the _components_ of a project. A _component_ is simply something that a project physically depends on ... using the word physically in a questionable way of course. A component differs from a project dependency (which we already represent) in a few ways:

1. it has a version number
2. it is not necessarily represented in Imbi as a project

There are two new entities -- the **component** and the **component-version**. Components are uniquely identified using a _package URL_ as defined by https://github.com/package-url/purl-spec. Component versions are precisely what they sound like -- a specific version associated with a component. There is also a new association between a project and the components that it depends on. These are stored in the `project_components` table.

```mermaid
erDiagram
  components {
    text package_url PK
    text name
    enum status
    text home_page
    text icon_class
    text active_version
  }
  component_versions {
    serial id
    text package_url PK, FK
    text version PK
  }
  project_components {
    int project_id PK, FK
    int version_id PK, FK
    text package_url FK
  }
  components }|--o{ component_versions : ""
  component_versions }|--o{ project_components : ""
  project_components |o--|| projects : ""
```

Note that the schema only represents the components for **a single version of a project**. In other words, we only track the versioned dependencies of the current version of the project where _current_ is defined as whatever is in the database at a specific instance in time. Imbi does not track multiple concurrent versions of a project nor historical versions of a project.

The inclusion of the `component_versions.id` surrogate key is there to facilitate adding columns to `component_versions` in the future as well as changing the version number without having the rewrite the relationship. I'm not completely sure if this is going to be necessary but it is easier to remove than it would be to add after the fact.

The last thing to note is that only the components are directly editable via an API so the component version and project components lack the common audit fields (eg, `created_by`, `modified_by`).