### PR TITLE
Add surrogate PK for v1.aws_roles

### DIFF
--- a/tables/v1/aws_roles.sql
+++ b/tables/v1/aws_roles.sql
@@ -1,12 +1,12 @@
 SET SEARCH_PATH TO v1;
 
 CREATE TABLE IF NOT EXISTS aws_roles (
+    id            SERIAL                    NOT NULL  PRIMARY KEY,
     role_arn      TEXT                      NOT NULL,
     environment   TEXT                      NOT NULL,
     namespace_id  INTEGER                   NOT NULL,
     created_at    TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
     created_by    TEXT                      NOT NULL,
-    PRIMARY KEY (role_arn, environment, namespace_id),
     UNIQUE (environment, namespace_id),
     FOREIGN KEY (environment) REFERENCES environments (name) ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (namespace_id) REFERENCES namespaces (id) ON DELETE CASCADE ON UPDATE CASCADE
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS aws_roles (
 
 COMMENT ON TABLE aws_roles IS 'AWS roles with permissions in the given environment and namespace';
 
+COMMENT ON COLUMN aws_roles.id IS 'Surrogate key for AWS roles';
 COMMENT ON COLUMN aws_roles.role_arn IS 'AWS ARN of the role';
 COMMENT ON COLUMN aws_roles.environment IS 'Name of the environment this role is associated with';
 COMMENT ON COLUMN aws_roles.namespace_id IS 'ID of the namespace this role is associated with';


### PR DESCRIPTION
This will allow us to make a more straightforward API path for CRUD operations on aws roles. There is no natural ordering for the natural key parts, and using an `id` follows our common pattern for tables like this that are updated by admins.