### PR TITLE
Add v1.component_versions.status column

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -15,6 +15,7 @@ schemata/v1.sql
 types/v1/automation_category_type.sql
 types/v1/change_type.sql
 types/v1/component_status_type.sql
+types/v1/component_version_status_type.sql
 types/v1/configuration_type.sql
 types/v1/cookie_cutter_type.sql
 types/v1/data_type.sql

--- a/tables/v1/component_versions.sql
+++ b/tables/v1/component_versions.sql
@@ -2,9 +2,10 @@ SET SEARCH_PATH TO v1;
 
 CREATE TABLE IF NOT EXISTS v1.component_versions
 (
-    id          SERIAL UNIQUE NOT NULL,
-    package_url TEXT          NOT NULL,
-    version     TEXT          NOT NULL,
+    id          SERIAL UNIQUE                    NOT NULL,
+    package_url TEXT                             NOT NULL,
+    version     TEXT                             NOT NULL,
+    status      v1.component_version_status_type NOT NULL DEFAULT 'Unscored',
     PRIMARY KEY (package_url, version),
     UNIQUE (package_url, id),
     FOREIGN KEY (package_url) REFERENCES v1.components (package_url) ON DELETE CASCADE ON UPDATE CASCADE
@@ -14,6 +15,7 @@ COMMENT ON TABLE v1.component_versions IS 'Versions of a component that are/were
 COMMENT ON COLUMN v1.component_versions.id IS 'Surrogate identifier for the version';
 COMMENT ON COLUMN v1.component_versions.package_url IS 'Identifies the component (FK v1.components.package_url)';
 COMMENT ON COLUMN v1.component_versions.version IS 'Version of the component bound to the surrogate ID';
+COMMENT ON COLUMN v1.component_versions.status IS 'Status of this specific component version with respect to the components active version';
 
 GRANT SELECT ON v1.component_versions TO reader;
 GRANT SELECT ON v1.component_versions TO writer;

--- a/tests/test_v1_component_versions.sql
+++ b/tests/test_v1_component_versions.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(18);
+SELECT plan(19);
 
 -- fixtures
 INSERT INTO v1.components(package_url, name, created_by)
@@ -18,6 +18,7 @@ SELECT lives_ok($$INSERT INTO v1.component_versions(package_url, version)
                          ('pkg:second', '1'), ('pkg:second', '2')$$);
 SELECT lives_ok($$DELETE FROM v1.components WHERE package_url = 'pkg:second'$$);
 SELECT results_eq($$SELECT COUNT(id)::INT AS c FROM v1.component_versions$$, ARRAY [1]);
+SELECT results_eq($$SELECT status FROM v1.component_versions$$, ARRAY ['Unscored'::v1.component_version_status_type]);
 
 -- permission tests
 SET ROLE TO reader;

--- a/types/v1/component_version_status_type.sql
+++ b/types/v1/component_version_status_type.sql
@@ -1,0 +1,10 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TYPE component_version_status_type
+    AS ENUM ('Deprecated',
+             'Forbidden',
+             'Outdated',
+             'Unscored',
+             'Up-to-date');
+
+COMMENT ON TYPE v1.component_version_status_type IS 'Status of a specific version of a component with respect to components.active_version';


### PR DESCRIPTION
We can store the per-version component status in the database instead of recalculating it. This does mean that manually changing values in the database **IS NOT SUPPORTED**. Part of the reason that I was calculating it on the fly was to ensure that the per-version status was *always* congruent with the state of the related component.

I am adding a report that show any project that contains outdated components (eg, those with a per-version status that is not `Up-to-date` or `Unscored`). Having the per-version score in the database makes this simple and also greatly simplifies the other project-related APIs.

**There is a deployment wrinkle** if you have enabled scoring, then you will need to replicate the per-version scores into the new column. For components without an active version, you can copy the component status directly since the enums intentionally match. Sorry for the ugly casting 😦 
```sql
UPDATE v1.component_versions AS v
   SET v.status = CAST(c.status AS TEXT)::v1.component_version_status_type
  FROM v1.components AS c
 WHERE c.status IN ('Deprecated', 'Forbidden')
   AND c.status::TEXT != v.status::TEXT
```

Any components with an active version set will need to have the per-version status set manually. If you have a lot of them, then you can probably write a python script for the migration using the code that I added to the API.