### PR TITLE
Add v1.operations_log.occurred_at

### DIFF
--- a/tables/v1/operations_log.sql
+++ b/tables/v1/operations_log.sql
@@ -2,6 +2,7 @@ SET search_path=v1, public, pg_catalog;
 
 CREATE TABLE IF NOT EXISTS operations_log (
   id            BIGINT                    NOT NULL  GENERATED ALWAYS AS IDENTITY  PRIMARY KEY,
+  occurred_at   TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
   recorded_at   TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
   recorded_by   TEXT                      NOT NULL,
   completed_at  TIMESTAMP WITH TIME ZONE,
@@ -19,7 +20,8 @@ CREATE TABLE IF NOT EXISTS operations_log (
 
 COMMENT ON TABLE operations_log IS 'An audit log of entity operational changes';
 COMMENT ON COLUMN operations_log.id IS 'A surrogate key for modifying and deleting the record';
-COMMENT ON COLUMN operations_log.recorded_at IS 'When the change occurred';
+COMMENT ON COLUMN operations_log.occurred_at IS 'When the change occurred (user input)';
+COMMENT ON COLUMN operations_log.recorded_at IS 'When the record was created';
 COMMENT ON COLUMN operations_log.recorded_by IS 'The user who recorded the change';
 COMMENT ON COLUMN operations_log.completed_at IS 'If specified, indicates the change occurred over a span of time';
 COMMENT ON COLUMN operations_log.project_id IS 'The optional ID of the project for the change';


### PR DESCRIPTION
This column tracks the user specified time at which an event occurred which is not necessarily the same as the time at which the event was created in the database (eg, `recorded_at`).

This requires a migration step to add the new column with a default.
```sql
ALTER TABLE v1.operations_log
ADD COLUMN IF NOT EXISTS occurred_at TIMESTAMP WITH TIME ZONE;

UPDATE v1.operations_log
   SET occurred_at = recorded_at
 WHERE occurred_at IS NULL;

ALTER TABLE v1.operations_log
ALTER COLUMN occurred_at SET DEFAULT CURRENT_TIMESTAMP,
ALTER COLUMN occurred_at SET NOT NULL;

COMMENT ON COLUMN v1.operations_log.occurred_at IS 'When the change occurred (user input)';

```