### PR TITLE
Add operations_log.performed_by

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -41,7 +41,6 @@ tables/v1/project_types.sql
 tables/v1/available_automations.sql
 tables/v1/cookie_cutters.sql
 tables/v1/projects.sql
-tables/v1/operations_log.sql
 tables/v1/project_components.sql
 tables/v1/project_dependencies.sql
 tables/v1/project_fact_types.sql
@@ -58,6 +57,7 @@ tables/v1/project_secrets.sql
 tables/v1/project_score_history.sql
 tables/v1/project_urls.sql
 tables/v1/users.sql
+tables/v1/operations_log.sql
 tables/v1/authentication_tokens.sql
 tables/v1/groups.sql
 tables/v1/group_members.sql

--- a/tables/v1/operations_log.sql
+++ b/tables/v1/operations_log.sql
@@ -12,17 +12,20 @@ CREATE TABLE IF NOT EXISTS operations_log (
   description   TEXT                      NOT NULL,
   link          TEXT,
   notes         TEXT,
+  performed_by  TEXT,
   ticket_slug   TEXT,
   version       TEXT,
   FOREIGN KEY (project_id) REFERENCES v1.projects (id) ON UPDATE CASCADE ON DELETE CASCADE,
-  FOREIGN KEY (environment) REFERENCES v1.environments (name) ON UPDATE CASCADE ON DELETE CASCADE
+  FOREIGN KEY (environment) REFERENCES v1.environments (name) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (performed_by) REFERENCES v1.users (username) ON UPDATE CASCADE ON DELETE SET NULL
 );
 
 COMMENT ON TABLE operations_log IS 'An audit log of entity operational changes';
 COMMENT ON COLUMN operations_log.id IS 'A surrogate key for modifying and deleting the record';
 COMMENT ON COLUMN operations_log.occurred_at IS 'When the change occurred (user input)';
 COMMENT ON COLUMN operations_log.recorded_at IS 'When the record was created';
-COMMENT ON COLUMN operations_log.recorded_by IS 'The user who recorded the change';
+COMMENT ON COLUMN operations_log.recorded_by IS 'The authenticated user who recorded the change';
+COMMENT ON COLUMN operations_log.performed_by IS 'Optional user to display (user input)';
 COMMENT ON COLUMN operations_log.completed_at IS 'If specified, indicates the change occurred over a span of time';
 COMMENT ON COLUMN operations_log.project_id IS 'The optional ID of the project for the change';
 COMMENT ON COLUMN operations_log.environment IS 'The operational environment the change was made in';
@@ -33,6 +36,7 @@ COMMENT ON COLUMN operations_log.notes IS 'Optional notes for the change in mark
 COMMENT ON COLUMN operations_log.ticket_slug IS 'An optional slug of the ticket that the change was made for';
 COMMENT ON COLUMN operations_log.version IS 'An optional version that the change was made for';
 
+CREATE INDEX ON operations_log (performed_by);
 CREATE INDEX ON operations_log (project_id);
 CREATE INDEX ON operations_log (recorded_at);
 


### PR DESCRIPTION
This is a user-input column that is used to override `recorded_by` for display purposes. I decided to force referential integrity against `users.username` and `NULL`ify the field when the user is deleted. We _should_ be doing something like this for `recorded_by` but that will take some additional thought since we assume that it is never `NULL`.

<details><summary>Migration Script</summary>
<p>

```sql
ALTER TABLE v1.operations_log
  ADD COLUMN IF NOT EXISTS performed_by TEXT;

COMMENT ON COLUMN v1.operations_log.recorded_by IS 'The authenticated user who recorded the change';
COMMENT ON COLUMN v1.operations_log.performed_by IS 'Optional user to display (user input)';

UPDATE v1.operations_log
   SET performed_by = recorded_by
 WHERE EXISTS (SELECT username
                 FROM v1.users
                WHERE username = recorded_by);

ALTER TABLE v1.operations_log
  ADD FOREIGN KEY (performed_by) REFERENCES v1.users(username)
   ON UPDATE CASCADE
   ON DELETE SET NULL;

CREATE INDEX ON v1.operations_log (performed_by);
```

</p>
</details> 